### PR TITLE
fix: fix bugs after testing

### DIFF
--- a/contracts/adapters/aave/WrappedAToken.sol
+++ b/contracts/adapters/aave/WrappedAToken.sol
@@ -107,8 +107,11 @@ contract WrappedAToken is ERC20, IWrappedAToken {
 
     /// @dev Gives lending pool max approval for underlying if it falls below `amount`
     function _ensureAllowance(uint256 amount) internal {
-        if (underlying.allowance(address(this), address(lendingPool)) < amount) {
-            underlying.safeApprove(address(lendingPool), type(uint256).max);
+        uint256 allowance = underlying.allowance(address(this), address(lendingPool));
+        if (allowance < amount) {
+            unchecked {
+                underlying.safeIncreaseAllowance(address(lendingPool), type(uint256).max - allowance);
+            }
         }
     }
 }

--- a/contracts/adapters/compound/CompoundV2_CErc20Adapter.sol
+++ b/contracts/adapters/compound/CompoundV2_CErc20Adapter.sol
@@ -107,7 +107,7 @@ contract CompoundV2_CErc20Adapter is CompoundV2_CTokenAdapter {
     ///      - underlying is enabled after the call
     ///      - cToken is not disabled after the call because operation doesn't spend the entire balance
     function _redeemUnderlying(uint256 amount) internal override returns (uint256 error) {
-        error = abi.decode(_encodeRedeemUnderlying(amount), (uint256));
+        error = abi.decode(_execute(_encodeRedeemUnderlying(amount)), (uint256));
         _changeEnabledTokens(tokenMask, 0);
     }
 }

--- a/contracts/adapters/compound/CompoundV2_CEtherAdapter.sol
+++ b/contracts/adapters/compound/CompoundV2_CEtherAdapter.sol
@@ -112,7 +112,7 @@ contract CompoundV2_CEtherAdapter is CompoundV2_CTokenAdapter {
     ///      - cETH is not disabled after the call because operation doesn't spend the entire balance
     function _redeemUnderlying(uint256 amount) internal override returns (uint256 error) {
         _approveToken(cToken, type(uint256).max);
-        error = abi.decode(_encodeRedeemUnderlying(amount), (uint256));
+        error = abi.decode(_execute(_encodeRedeemUnderlying(amount)), (uint256));
         _approveToken(cToken, 1);
         _changeEnabledTokens(tokenMask, 0);
     }

--- a/contracts/interfaces/aave/IWrappedAToken.sol
+++ b/contracts/interfaces/aave/IWrappedAToken.sol
@@ -15,13 +15,13 @@ interface IWrappedAToken is IERC20Metadata {
     /// @param account Account that performed deposit
     /// @param assets Amount of deposited aTokens
     /// @param shares Amount of waTokens minted to account
-    event Deposit(address account, uint256 assets, uint256 shares);
+    event Deposit(address indexed account, uint256 assets, uint256 shares);
 
     /// @notice Emitted on withdrawal
     /// @param account Account that performed withdrawal
     /// @param assets Amount of withdrawn aTokens
     /// @param shares Amount of waTokens burnt from account
-    event Withdraw(address account, uint256 assets, uint256 shares);
+    event Withdraw(address indexed account, uint256 assets, uint256 shares);
 
     /// @notice Underlying aToken
     function aToken() external view returns (IAToken);


### PR DESCRIPTION
* make `account` field of `IWrappedAToken`'s `Deposit` and `Withdraw` events indexed
* add missing `_execute` in `redeemUnderlying` method of `CompoundV2_CErc20Adapter` and `CompoundV2_CEtherAdapter` (lol)
* replace failing `safeApprove` with `safeIncreaseAllowance` in `WrappedAToken` and `WstETHGateway` (note that simple `approve` might not work very good in both cases, unlike the same scenario in `WrappedATokengGateway`)