### PR TITLE
feat: curveV2 bugfix + config fixes

### DIFF
--- a/config/creditManagers.ts
+++ b/config/creditManagers.ts
@@ -385,8 +385,8 @@ export const mainnetCreditManagers: Array<CMConfig> = [
   },
   {
     symbol: "OHM",
-    minAmount: WAD.mul(15000),
-    maxAmount: WAD.mul(100000),
+    minAmount: BigNumber.from(10).pow(9).mul(15000),
+    maxAmount: BigNumber.from(10).pow(9).mul(100000),
     collateralTokens: [
       // Liquidation threshold will be multiplied x100 to be used as CreditFilter.sol contract parameter
 
@@ -400,6 +400,7 @@ export const mainnetCreditManagers: Array<CMConfig> = [
       { symbol: "GUSD", liquidationThreshold: 85 }, // Token address is token from priceFeed map above
       { symbol: "LUSD", liquidationThreshold: 85 }, // Token address is token from priceFeed map above
       { symbol: "FRAX", liquidationThreshold: 85 },
+      { symbol: "MIM", liquidationThreshold: 80 },
 
       { symbol: "3Crv", liquidationThreshold: 85 }, // Token address is token from priceFeed map above
       { symbol: "cvx3Crv", liquidationThreshold: 85 }, // Token address is token from priceFeed map above
@@ -429,11 +430,16 @@ export const mainnetCreditManagers: Array<CMConfig> = [
       { symbol: "cvxOHMFRAXBP", liquidationThreshold: 85 }, // Token address is token from priceFeed map above
       { symbol: "stkcvxOHMFRAXBP", liquidationThreshold: 85 }, // Token address is token from priceFeed map above
 
+      { symbol: "MIM_3LP3CRV", liquidationThreshold: 85 }, // Token address is token from priceFeed map above
+      { symbol: "cvxMIM_3LP3CRV", liquidationThreshold: 85 }, // Token address is token from priceFeed map above
+      { symbol: "stkcvxMIM_3LP3CRV", liquidationThreshold: 85 }, // Token address is token from priceFeed map above
+
       { symbol: "CVX", liquidationThreshold: 25 }, // Token address is token from priceFeed map above
       { symbol: "FXS", liquidationThreshold: 25 }, // Token address is token from priceFeed map above
       { symbol: "LQTY", liquidationThreshold: 0 },
       { symbol: "CRV", liquidationThreshold: 25 }, // Token address is token from priceFeed map above
       { symbol: "SNX", liquidationThreshold: 25 }, // Token address is token from priceFeed map above
+      { symbol: "SPELL", liquidationThreshold: 25 },
     ],
     adapters: [
       /// SWAPPERS
@@ -450,6 +456,7 @@ export const mainnetCreditManagers: Array<CMConfig> = [
       "CURVE_GUSD_POOL",
       "CURVE_SUSD_DEPOSIT",
       "CURVE_OHMFRAXBP_POOL",
+      "CURVE_MIM_POOL",
 
       // CONVEX
       "CONVEX_FRAX3CRV_POOL",
@@ -459,6 +466,7 @@ export const mainnetCreditManagers: Array<CMConfig> = [
       "CONVEX_3CRV_POOL",
       "CONVEX_FRAX_USDC_POOL",
       "CONVEX_OHMFRAXBP_POOL",
+      "CONVEX_MIM3CRV_POOL",
       "CONVEX_BOOSTER",
 
       // BALANCER

--- a/contracts/test/config/CreditConfigLive.sol
+++ b/contracts/test/config/CreditConfigLive.sol
@@ -535,8 +535,8 @@ contract CreditConfigLive {
         cm = creditManagerHumanOpts[numOpts];
         ++numOpts;
         cm.underlying = Tokens.OHM;
-        cm.minBorrowedAmount = 15000000000000000000000;
-        cm.maxBorrowedAmount = 100000000000000000000000;
+        cm.minBorrowedAmount = 15000000000000;
+        cm.maxBorrowedAmount = 100000000000000;
         cm.degenNFT = address(0);
         cm.blacklistHelper = address(0);
         cm.expirable = false;
@@ -550,6 +550,7 @@ contract CreditConfigLive {
         cm.collateralTokens.push(CollateralTokenHuman({token: Tokens.GUSD, liquidationThreshold: 8500}));
         cm.collateralTokens.push(CollateralTokenHuman({token: Tokens.LUSD, liquidationThreshold: 8500}));
         cm.collateralTokens.push(CollateralTokenHuman({token: Tokens.FRAX, liquidationThreshold: 8500}));
+        cm.collateralTokens.push(CollateralTokenHuman({token: Tokens.MIM, liquidationThreshold: 8000}));
         cm.collateralTokens.push(CollateralTokenHuman({token: Tokens._3Crv, liquidationThreshold: 8500}));
         cm.collateralTokens.push(CollateralTokenHuman({token: Tokens.cvx3Crv, liquidationThreshold: 8500}));
         cm.collateralTokens.push(CollateralTokenHuman({token: Tokens.stkcvx3Crv, liquidationThreshold: 8500}));
@@ -573,11 +574,15 @@ contract CreditConfigLive {
         cm.collateralTokens.push(CollateralTokenHuman({token: Tokens.OHMFRAXBP, liquidationThreshold: 8500}));
         cm.collateralTokens.push(CollateralTokenHuman({token: Tokens.cvxOHMFRAXBP, liquidationThreshold: 8500}));
         cm.collateralTokens.push(CollateralTokenHuman({token: Tokens.stkcvxOHMFRAXBP, liquidationThreshold: 8500}));
+        cm.collateralTokens.push(CollateralTokenHuman({token: Tokens.MIM_3LP3CRV, liquidationThreshold: 8500}));
+        cm.collateralTokens.push(CollateralTokenHuman({token: Tokens.cvxMIM_3LP3CRV, liquidationThreshold: 8500}));
+        cm.collateralTokens.push(CollateralTokenHuman({token: Tokens.stkcvxMIM_3LP3CRV, liquidationThreshold: 8500}));
         cm.collateralTokens.push(CollateralTokenHuman({token: Tokens.CVX, liquidationThreshold: 2500}));
         cm.collateralTokens.push(CollateralTokenHuman({token: Tokens.FXS, liquidationThreshold: 2500}));
         cm.collateralTokens.push(CollateralTokenHuman({token: Tokens.LQTY, liquidationThreshold: 1}));
         cm.collateralTokens.push(CollateralTokenHuman({token: Tokens.CRV, liquidationThreshold: 2500}));
         cm.collateralTokens.push(CollateralTokenHuman({token: Tokens.SNX, liquidationThreshold: 2500}));
+        cm.collateralTokens.push(CollateralTokenHuman({token: Tokens.SPELL, liquidationThreshold: 2500}));
         cm.contracts.push(Contracts.UNISWAP_V3_ROUTER);
         cm.contracts.push(Contracts.UNISWAP_V2_ROUTER);
         cm.contracts.push(Contracts.SUSHISWAP_ROUTER);
@@ -589,6 +594,7 @@ contract CreditConfigLive {
         cm.contracts.push(Contracts.CURVE_GUSD_POOL);
         cm.contracts.push(Contracts.CURVE_SUSD_DEPOSIT);
         cm.contracts.push(Contracts.CURVE_OHMFRAXBP_POOL);
+        cm.contracts.push(Contracts.CURVE_MIM_POOL);
         cm.contracts.push(Contracts.CONVEX_FRAX3CRV_POOL);
         cm.contracts.push(Contracts.CONVEX_LUSD3CRV_POOL);
         cm.contracts.push(Contracts.CONVEX_GUSD_POOL);
@@ -596,6 +602,7 @@ contract CreditConfigLive {
         cm.contracts.push(Contracts.CONVEX_3CRV_POOL);
         cm.contracts.push(Contracts.CONVEX_FRAX_USDC_POOL);
         cm.contracts.push(Contracts.CONVEX_OHMFRAXBP_POOL);
+        cm.contracts.push(Contracts.CONVEX_MIM3CRV_POOL);
         cm.contracts.push(Contracts.CONVEX_BOOSTER);
         cm.contracts.push(Contracts.BALANCER_VAULT);
         cm.balancerPools.push(


### PR DESCRIPTION
Some CurveV2 pools have `calc_token_amount()` with a signature that differs from previous pools (the last `bool` input is omitted). The adapter's `calc_add_one_coin()` function was changed to properly handle that.