### PR TITLE
feat: add pool zappers

### DIFF
--- a/contracts/zappers/WATokenZapper.sol
+++ b/contracts/zappers/WATokenZapper.sol
@@ -5,6 +5,8 @@ pragma solidity ^0.8.17;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
+import {WAD} from "@gearbox-protocol/core-v2/contracts/libraries/Constants.sol";
+
 import {IWrappedAToken} from "../interfaces/aave/IWrappedAToken.sol";
 import {WERC20ZapperBase} from "./WERC20ZapperBase.sol";
 
@@ -34,6 +36,16 @@ contract WATokenZapper is WERC20ZapperBase {
     /// @dev Unwraps waToken
     function _unwrap(uint256 assets) internal override returns (uint256 amount) {
         return IWrappedAToken(wrappedToken).withdraw(assets);
+    }
+
+    /// @dev Returns amount of waToken one would receive for wrapping `amount` of aToken
+    function _previewWrap(uint256 amount) internal view override returns (uint256 wrappedAmount) {
+        return amount * WAD / IWrappedAToken(wrappedToken).exchangeRate();
+    }
+
+    /// @dev Returns amount of aToken one would receive for unwrapping `amount` of waToken
+    function _previewUnwrap(uint256 amount) internal view override returns (uint256 unwrappedAmount) {
+        return amount * IWrappedAToken(wrappedToken).exchangeRate() / WAD;
     }
 
     /// @dev Pool has infinite waToken allowance so this step can be skipped

--- a/contracts/zappers/WATokenZapper.sol
+++ b/contracts/zappers/WATokenZapper.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Gearbox Protocol. Generalized leverage for DeFi protocols
+// (c) Gearbox Foundation, 2023.
+pragma solidity ^0.8.17;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {IWrappedAToken} from "../interfaces/aave/IWrappedAToken.sol";
+import {WERC20ZapperBase} from "./WERC20ZapperBase.sol";
+
+/// @title waToken zapper
+/// @notice Allows users to deposit/withdraw an aToken to/from a waToken pool in a single operation
+contract WATokenZapper is WERC20ZapperBase {
+    /// @dev aToken address
+    address internal immutable _aToken;
+
+    /// @notice Constructor
+    /// @param pool_ Pool to connect this zapper to
+    constructor(address pool_) WERC20ZapperBase(pool_) {
+        _aToken = address(IWrappedAToken(wrappedToken).aToken());
+        IERC20(_aToken).approve(wrappedToken, type(uint256).max);
+    }
+
+    /// @notice aToken address
+    function unwrappedToken() public view override returns (address) {
+        return _aToken;
+    }
+
+    /// @dev Wraps aToken
+    function _wrap(uint256 amount) internal override returns (uint256 assets) {
+        return IWrappedAToken(wrappedToken).deposit(amount);
+    }
+
+    /// @dev Unwraps waToken
+    function _unwrap(uint256 assets) internal override returns (uint256 amount) {
+        return IWrappedAToken(wrappedToken).withdraw(assets);
+    }
+
+    /// @dev Pool has infinite waToken allowance so this step can be skipped
+    function _ensurePoolAllowance(uint256) internal override {}
+}

--- a/contracts/zappers/WERC20ZapperBase.sol
+++ b/contracts/zappers/WERC20ZapperBase.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Gearbox Protocol. Generalized leverage for DeFi protocols
+// (c) Gearbox Foundation, 2023.
+pragma solidity ^0.8.17;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {ZapperBase} from "./ZapperBase.sol";
+
+/// @title wERC20 zapper base
+/// @notice Base contract for zappers allowing users to deposit/withdraw an ERC20 token
+///         to/from a Gearbox pool with its wrapper as underlying in a single operation
+/// @dev Default implementation assumes that unwrapped token has no transfer fees
+abstract contract WERC20ZapperBase is ZapperBase {
+    /// @notice Constructor
+    /// @param pool_ Pool to connect this zapper to
+    constructor(address pool_) ZapperBase(pool_) {}
+
+    /// @dev Returns uwnrapped token, must be overriden by derived zappers
+    function unwrappedToken() public view virtual returns (address);
+
+    /// @notice Zaps wrapping a token and depositing it to the pool into a single operation
+    function deposit(uint256 amount, address receiver) external returns (uint256 shares) {
+        shares = _deposit(amount, receiver);
+    }
+
+    /// @notice Same as `deposit` but allows to specify the referral code
+    function depositWithUnderlying(uint256 amount, address receiver, uint16 referralCode)
+        external
+        returns (uint256 shares)
+    {
+        shares = _depositWithReferral(amount, receiver, referralCode);
+    }
+
+    /// @notice Zaps redeeming token from the pool and unwrapping it into a single operation
+    function redeem(uint256 shares, address receiver, address owner) external returns (uint256 amount) {
+        amount = _redeem(shares, receiver, owner);
+    }
+
+    /// @dev Receives unwrapped token from `msg.sender` and wraps it
+    function _receiveAndWrap(uint256 amount) internal virtual override returns (uint256 wrappedAmount) {
+        IERC20(unwrappedToken()).transferFrom(msg.sender, address(this), amount);
+        _ensureWrapperAllowance(amount);
+        wrappedAmount = _wrap(amount);
+    }
+
+    /// @dev Unwraps pool's underlying and sends it to `receiver`
+    function _unwrapAndSend(uint256 amount, address receiver)
+        internal
+        virtual
+        override
+        returns (uint256 unwrappedAmount)
+    {
+        unwrappedAmount = _unwrap(amount);
+        IERC20(unwrappedToken()).transfer(receiver, unwrappedAmount);
+    }
+
+    /// @dev Wraps unwrapped token, must be overriden by derived zappers
+    function _wrap(uint256 amount) internal virtual returns (uint256);
+
+    /// @dev Unwraps wrapped token, must be overriden by derived zappers
+    function _unwrap(uint256 amount) internal virtual returns (uint256);
+
+    /// @dev Gives `wrappedToken` max allowance for the `unwrappedToken()` if it falls below `amount`
+    function _ensureWrapperAllowance(uint256 amount) internal virtual {
+        _ensureAllowance(unwrappedToken(), wrappedToken, amount);
+    }
+}

--- a/contracts/zappers/WETHZapper.sol
+++ b/contracts/zappers/WETHZapper.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Gearbox Protocol. Generalized leverage for DeFi protocols
+// (c) Gearbox Foundation, 2023.
+pragma solidity ^0.8.17;
+
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+import {IWETH} from "@gearbox-protocol/core-v2/contracts/interfaces/external/IWETH.sol";
+import {ReceiveIsNotAllowedException} from "@gearbox-protocol/core-v3/contracts/interfaces/IExceptions.sol";
+
+import {ZapperBase} from "./ZapperBase.sol";
+
+/// @title WETH zapper
+/// @notice Allows users to deposit/withdraw pure ETH to/from a WETH pool in a single operation
+contract WETHZapper is ZapperBase {
+    /// @notice Constructor
+    /// @param pool_ Pool to connect this zapper to
+    constructor(address pool_) ZapperBase(pool_) {}
+
+    /// @notice Allows this contract to unwrap WETH and forbids other direct ETH transfers
+    receive() external payable {
+        if (msg.sender != wrappedToken) revert ReceiveIsNotAllowedException();
+    }
+
+    /// @notice Zaps wrapping ETH and depositing it to the pool into a single operation
+    function deposit(address receiver) external payable returns (uint256 shares) {
+        shares = _deposit(msg.value, receiver);
+    }
+
+    /// @notice Same as `deposit` but allows to specify the referral code
+    function depositWithReferral(address receiver, uint16 referralCode) external payable returns (uint256 shares) {
+        shares = _depositWithReferral(msg.value, receiver, referralCode);
+    }
+
+    /// @notice Zaps redeeming WETH from the pool and unwrapping it into a single operation
+    function redeem(uint256 shares, address receiver, address owner) external returns (uint256 amount) {
+        amount = _redeem(shares, receiver, owner);
+    }
+
+    /// @dev Wraps ETH
+    function _receiveAndWrap(uint256 amount) internal override returns (uint256 wrappedAmount) {
+        IWETH(wrappedToken).deposit{value: amount}();
+        return amount;
+    }
+
+    /// @dev Unwraps WETH and sends it to `receiver`
+    function _unwrapAndSend(uint256 amount, address receiver) internal override returns (uint256 unwrappedAmount) {
+        IWETH(wrappedToken).withdraw(amount);
+        Address.sendValue(payable(receiver), amount);
+        return amount;
+    }
+
+    /// @dev Pool has infinite WETH allowance so this step can be skipped
+    function _ensurePoolAllowance(uint256) internal override {}
+}

--- a/contracts/zappers/WETHZapper.sol
+++ b/contracts/zappers/WETHZapper.sol
@@ -50,6 +50,16 @@ contract WETHZapper is ZapperBase {
         return amount;
     }
 
+    /// @dev Returns amount of WETH one would receive for wrapping `amount` of ETH
+    function _previewWrap(uint256 amount) internal pure override returns (uint256 wrappedAmount) {
+        return amount;
+    }
+
+    /// @dev Returns amount of ETH one would receive for unwrapping `amount` of WETH
+    function _previewUnwrap(uint256 amount) internal pure override returns (uint256 unwrappedAmount) {
+        return amount;
+    }
+
     /// @dev Pool has infinite WETH allowance so this step can be skipped
     function _ensurePoolAllowance(uint256) internal override {}
 }

--- a/contracts/zappers/WstETHZapper.sol
+++ b/contracts/zappers/WstETHZapper.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Gearbox Protocol. Generalized leverage for DeFi protocols
+// (c) Gearbox Foundation, 2023.
+pragma solidity ^0.8.17;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {IwstETH} from "../integrations/lido/IwstETH.sol";
+import {WERC20ZapperBase} from "./WERC20ZapperBase.sol";
+
+/// @title wstETH zapper
+/// @notice Allows users to deposit/withdraw stETH to/from a wstETH pool in a single operation
+contract WstETHZapper is WERC20ZapperBase {
+    /// @dev stETH address
+    address internal immutable _stETH;
+
+    /// @notice Constructor
+    /// @param pool_ Pool to connect this zapper to
+    constructor(address pool_) WERC20ZapperBase(pool_) {
+        _stETH = IwstETH(wrappedToken).stETH();
+        IERC20(_stETH).approve(wrappedToken, type(uint256).max);
+    }
+
+    /// @notice stETH address
+    function unwrappedToken() public view override returns (address) {
+        return _stETH;
+    }
+
+    /// @dev Wraps stETH
+    function _wrap(uint256 amount) internal override returns (uint256 assets) {
+        return IwstETH(wrappedToken).wrap(amount);
+    }
+
+    /// @dev Unwraps wstETH
+    function _unwrap(uint256 assets) internal override returns (uint256 amount) {
+        return IwstETH(wrappedToken).unwrap(assets);
+    }
+}

--- a/contracts/zappers/WstETHZapper.sol
+++ b/contracts/zappers/WstETHZapper.sol
@@ -35,4 +35,14 @@ contract WstETHZapper is WERC20ZapperBase {
     function _unwrap(uint256 assets) internal override returns (uint256 amount) {
         return IwstETH(wrappedToken).unwrap(assets);
     }
+
+    /// @dev Returns amount of wstETH one would receive for wrapping `amount` of stETH
+    function _previewWrap(uint256 amount) internal view override returns (uint256 wrappedAmount) {
+        return IwstETH(wrappedToken).getWstETHByStETH(amount);
+    }
+
+    /// @dev Returns amount of stETH one would receive for unwrapping `amount` of wstETH
+    function _previewUnwrap(uint256 amount) internal view override returns (uint256 unwrappedAmount) {
+        return IwstETH(wrappedToken).getStETHByWstETH(amount);
+    }
 }

--- a/contracts/zappers/ZapperBase.sol
+++ b/contracts/zappers/ZapperBase.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Gearbox Protocol. Generalized leverage for DeFi protocols
+// (c) Gearbox Foundation, 2023.
+pragma solidity ^0.8.17;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {IPoolV3} from "@gearbox-protocol/core-v3/contracts/interfaces/IPoolV3.sol";
+
+/// @title Zapper base
+/// @notice Base contract for zappers allowing users to deposit/withdraw an unwrapped token
+///         to/from a Gearbox pool with wrapped token as underlying in a single operation
+abstract contract ZapperBase {
+    /// @notice Pool this zapper is connected to
+    address public immutable pool;
+    /// @notice Underlying token of the pool
+    address public immutable wrappedToken;
+
+    /// @notice Constructor
+    /// @param pool_ Pool to connect this zapper to
+    constructor(address pool_) {
+        pool = pool_;
+        wrappedToken = IPoolV3(pool_).asset();
+        IERC20(wrappedToken).approve(pool_, type(uint256).max);
+    }
+
+    /// @dev Implementation of deposit zap
+    ///      - Receives `amount` of unwrapped token from `msg.sender` and wraps it
+    ///      - Deposits wrapped token into the pool and mints pool shares to `receiver`
+    function _deposit(uint256 amount, address receiver) internal virtual returns (uint256 shares) {
+        uint256 assets = _receiveAndWrap(amount);
+        _ensurePoolAllowance(assets);
+        shares = IPoolV3(pool).deposit(assets, receiver);
+    }
+
+    /// @dev Same as `_deposit` but allows to specify the referral code
+    function _depositWithReferral(uint256 amount, address receiver, uint16 referralCode)
+        internal
+        virtual
+        returns (uint256 shares)
+    {
+        uint256 assets = _receiveAndWrap(amount);
+        _ensurePoolAllowance(assets);
+        shares = IPoolV3(pool).depositWithReferral(assets, receiver, referralCode);
+    }
+
+    /// @dev Implementation of redeem zap
+    ///      - Burns `owner`'s pool shares and redeems wrapped token (requires `owner`'s approval)
+    ///      - Unwraps redeemed token and sends `amount` of unwrapped token to `receiver`
+    function _redeem(uint256 shares, address receiver, address owner) internal virtual returns (uint256 amount) {
+        uint256 assets = IPoolV3(pool).redeem(shares, address(this), owner);
+        amount = _unwrapAndSend(assets, receiver);
+    }
+
+    /// @dev Receives unwrapped token from `msg.sender` and wraps it, must be overriden by derived zappers
+    function _receiveAndWrap(uint256 amount) internal virtual returns (uint256 wrappedAmount);
+
+    /// @dev Unwraps pool's underlying and sends it to `receiver`, must be overriden by derived zappers
+    function _unwrapAndSend(uint256 amount, address receiver) internal virtual returns (uint256 unwrappedAmount);
+
+    /// @dev Gives `pool` max allowance for the `wrappedToken` if it falls below `amount`
+    function _ensurePoolAllowance(uint256 amount) internal virtual {
+        _ensureAllowance(wrappedToken, pool, amount);
+    }
+
+    /// @dev Gives `spender` max allowance for this contract's `token` if it falls below `amount`
+    function _ensureAllowance(address token, address spender, uint256 amount) internal {
+        if (IERC20(token).allowance(address(this), spender) < amount) {
+            IERC20(token).approve(spender, type(uint256).max);
+        }
+    }
+}

--- a/contracts/zappers/ZapperBase.sol
+++ b/contracts/zappers/ZapperBase.sol
@@ -24,6 +24,18 @@ abstract contract ZapperBase {
         IERC20(wrappedToken).approve(pool_, type(uint256).max);
     }
 
+    /// @notice Returns number of pool shares one would receive for depositing `amount` of unwrapped token
+    function previewDeposit(uint256 amount) external view returns (uint256 shares) {
+        uint256 assets = _previewWrap(amount);
+        return IPoolV3(pool).previewDeposit(assets);
+    }
+
+    /// @notice Returns amount of unwrapped token one would receive for redeeming `shares` of pool shares
+    function previewRedeem(uint256 shares) external view returns (uint256 amount) {
+        uint256 assets = IPoolV3(pool).previewRedeem(shares);
+        return _previewUnwrap(assets);
+    }
+
     /// @dev Implementation of deposit zap
     ///      - Receives `amount` of unwrapped token from `msg.sender` and wraps it
     ///      - Deposits wrapped token into the pool and mints pool shares to `receiver`
@@ -57,6 +69,14 @@ abstract contract ZapperBase {
 
     /// @dev Unwraps pool's underlying and sends it to `receiver`, must be overriden by derived zappers
     function _unwrapAndSend(uint256 amount, address receiver) internal virtual returns (uint256 unwrappedAmount);
+
+    /// @dev Returns amount of wrapped token one would receive for wrapping `amount` of unwrapped token,
+    ///      must be overriden by derived zappers
+    function _previewWrap(uint256 amount) internal view virtual returns (uint256 wrappedAmount);
+
+    /// @dev Returns amount of unwrapped token one would receive for unwrapping `amount` of wrapped token,
+    ///      must be overriden by derived zappers
+    function _previewUnwrap(uint256 amount) internal view virtual returns (uint256 unwrappedAmount);
 
     /// @dev Gives `pool` max allowance for the `wrappedToken` if it falls below `amount`
     function _ensurePoolAllowance(uint256 amount) internal virtual {


### PR DESCRIPTION
Formerly known as pool gateways, zappers allow to zap wrapping token and depositing it to the pool