### PR TITLE
fix: ci: build configs for export in npm dist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,9 @@ jobs:
         run: forge build
         timeout-minutes: 10
 
-      
+      - name: Build dist
+        run: yarn build
+
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v3
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ cache
 .env
 npm-root
 types
+dist

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "files": [
     "contracts",
-    "config"
+    "dist"
   ],
   "license": "BUSL-1.1",
   "scripts": {
@@ -24,7 +24,8 @@
     "lint": "eslint \"**/*.ts\" --fix",
     "lint:ci": "eslint \"**/*.ts\"",
     "typecheck:ci": "tsc --noEmit",
-    "forge-install": "forge install --no-commit foundry-rs/forge-std"
+    "forge-install": "forge install --no-commit foundry-rs/forge-std",
+    "build": "tsc --p tsconfig.build.json"
   },
   "dependencies": {},
   "devDependencies": {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "**/*.spec.ts",
+    "node_modules",
+    "dist",
+    "forge-out",
+    "scripts",
+    "lib"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,9 +14,9 @@
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     "declaration": true /* Generates corresponding '.d.ts' file. */,
     //    "composite": true,
-    "declarationMap": true,
+    // "declarationMap": true,
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    "sourceMap": true /* Generates corresponding '.map' file. */,
+    // "sourceMap": true /* Generates corresponding '.map' file. */,
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     //      "outDir": "./build",                        /* Redirect output structure to the directory. */
     //     "composite": true,                     /* Enable project compilation */
@@ -64,7 +64,7 @@
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
     "useUnknownInCatchVariables": false,
     "resolveJsonModule": true,
-    "outDir": "./npm-root/"
+    "outDir": "./dist"
   },
   "include": ["config"],
   "exclude": ["node_modules", "lib", "npm-root"]


### PR DESCRIPTION
To enable import of configs, we have to make build in dist