### PR TITLE
feat: remove `owner` from zappers' `redeem`/`redeemWithPermit`

### DIFF
--- a/contracts/interfaces/zappers/IZapper.sol
+++ b/contracts/interfaces/zappers/IZapper.sol
@@ -16,15 +16,9 @@ interface IZapper {
 
     function previewRedeem(uint256 tokenOutAmount) external view returns (uint256 tokenInAmount);
 
-    function redeem(uint256 tokenOutAmount, address receiver, address owner) external returns (uint256 tokenInAmount);
+    function redeem(uint256 tokenOutAmount, address receiver) external returns (uint256 tokenInAmount);
 
-    function redeemWithPermit(
-        uint256 tokenOutAmount,
-        address receiver,
-        address owner,
-        uint256 deadline,
-        uint8 v,
-        bytes32 r,
-        bytes32 s
-    ) external returns (uint256 tokenInAmount);
+    function redeemWithPermit(uint256 tokenOutAmount, address receiver, uint256 deadline, uint8 v, bytes32 r, bytes32 s)
+        external
+        returns (uint256 tokenInAmount);
 }

--- a/contracts/test/unit/zappers/ZapperBase.unit.t.sol
+++ b/contracts/test/unit/zappers/ZapperBase.unit.t.sol
@@ -397,9 +397,10 @@ contract ZapperBaseUnitTest is Test {
                     );
                 }
 
+                vm.prank(owner);
                 uint256 tokenInAmount = withPermit
-                    ? zapper.redeemWithPermit(cases[i].tokenOutAmount, receiver, owner, 0, 0, bytes32(0), bytes32(0))
-                    : zapper.redeem(cases[i].tokenOutAmount, receiver, owner);
+                    ? zapper.redeemWithPermit(cases[i].tokenOutAmount, receiver, 0, 0, bytes32(0), bytes32(0))
+                    : zapper.redeem(cases[i].tokenOutAmount, receiver);
 
                 assertEq(
                     tokenInAmount,

--- a/contracts/zappers/ZapperBase.sol
+++ b/contracts/zappers/ZapperBase.sol
@@ -70,30 +70,25 @@ abstract contract ZapperBase is IZapper {
     // --- //
 
     /// @notice Performs redeem zap:
-    ///         - receives `tokenOut` from `owner` and converts it to `pool`'s shares
+    ///         - receives `tokenOut` from `msg.sender` and converts it to `pool`'s shares
     ///         - redeems `pool`'s shares for `underlying`
     ///         - converts `underlying` to `tokenIn` and sends it to `receiver`
-    /// @dev Requires approval from `owner` for `tokenOut` to this contract
-    function redeem(uint256 tokenOutAmount, address receiver, address owner) external returns (uint256 tokenInAmount) {
-        tokenInAmount = _redeem(tokenOutAmount, receiver, owner);
+    /// @dev Requires approval from `msg.sender` for `tokenOut` to this contract
+    function redeem(uint256 tokenOutAmount, address receiver) external returns (uint256 tokenInAmount) {
+        tokenInAmount = _redeem(tokenOutAmount, receiver, msg.sender);
     }
 
     /// @notice Performs redeem zap using signed EIP-2612 permit message for zapper's output token:
-    ///         - receives `tokenOut` from `owner` and converts it to `pool`'s shares
+    ///         - receives `tokenOut` from `msg.sender` and converts it to `pool`'s shares
     ///         - redeems `pool`'s shares for `underlying`
     ///         - converts `underlying` to `tokenIn` and sends it to `receiver`
-    /// @dev `v`, `r`, `s` must be a valid signature of the permit message from `owner` for `tokenOut` to this contract
-    function redeemWithPermit(
-        uint256 tokenOutAmount,
-        address receiver,
-        address owner,
-        uint256 deadline,
-        uint8 v,
-        bytes32 r,
-        bytes32 s
-    ) external returns (uint256 tokenInAmount) {
-        try IERC20Permit(tokenOut()).permit(owner, address(this), tokenOutAmount, deadline, v, r, s) {} catch {} // U:[ZB-5]
-        tokenInAmount = _redeem(tokenOutAmount, receiver, owner);
+    /// @dev `v`, `r`, `s` must be a valid signature of the permit message from `msg.sender` for `tokenOut` to this contract
+    function redeemWithPermit(uint256 tokenOutAmount, address receiver, uint256 deadline, uint8 v, bytes32 r, bytes32 s)
+        external
+        returns (uint256 tokenInAmount)
+    {
+        try IERC20Permit(tokenOut()).permit(msg.sender, address(this), tokenOutAmount, deadline, v, r, s) {} catch {} // U:[ZB-5]
+        tokenInAmount = _redeem(tokenOutAmount, receiver, msg.sender);
     }
 
     /// @dev `deposit` and `depositWithReferral` implementation


### PR DESCRIPTION
ERC-4626's redeem allows to specify an arbitrary owner. This lets anyone with approval for owner's shares to execute redeem on their behalf. The issue arises when "anyone" is a contract with permissionless access, in this case, our zappers.

The current implementation allowed an attacker to:
1. backrun approve to zapper / frontrun `redeemWithPermit`
2. submit their own `redeem`/`redeemWithPermit` transaction that sends funds to arbitrary address

The fix is to remove owner from both redeem variants (we lose ERC-4626 compatibility though).