### PR TITLE
test(midas): audit harness, PoCs, invariants, and verified findings report

### DIFF
--- a/contracts/test/audit/midas/MidasAuditTestBase.sol
+++ b/contracts/test/audit/midas/MidasAuditTestBase.sol
@@ -1,0 +1,402 @@
+// SPDX-License-Identifier: UNLICENSED
+// Gearbox Protocol. Generalized leverage for DeFi protocols
+// (c) Gearbox Foundation, 2026.
+pragma solidity ^0.8.23;
+
+import {Test} from "forge-std/Test.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {ERC20Mock} from "@gearbox-protocol/core-v3/contracts/test/mocks/token/ERC20Mock.sol";
+import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
+
+import {MidasGateway} from "../../../helpers/midas/MidasGateway.sol";
+import {MidasRedeemer} from "../../../helpers/midas/MidasRedeemer.sol";
+import {MidasRedemptionVaultPhantomToken} from "../../../helpers/midas/MidasRedemptionVaultPhantomToken.sol";
+import {MidasLiquidator} from "../../../helpers/midas/MidasLiquidator.sol";
+import {IMidasGateway} from "../../../interfaces/midas/IMidasGateway.sol";
+import {IMidasTransferMaster} from "../../../interfaces/midas/IMidasTransferMaster.sol";
+import {IRedemptionLogger, AP_REDEMPTION_LOGGER} from "../../../interfaces/IRedemptionLogger.sol";
+
+import {ICreditManagerV3} from "@gearbox-protocol/core-v3/contracts/interfaces/ICreditManagerV3.sol";
+import {ICreditFacadeV3, MultiCall} from "@gearbox-protocol/core-v3/contracts/interfaces/ICreditFacadeV3.sol";
+import {ICreditFacadeV3Multicall} from "@gearbox-protocol/core-v3/contracts/interfaces/ICreditFacadeV3Multicall.sol";
+import {ICreditAccountV3} from "@gearbox-protocol/core-v3/contracts/interfaces/ICreditAccountV3.sol";
+import {IVersion} from "@gearbox-protocol/core-v3/contracts/interfaces/base/IVersion.sol";
+import {IAddressProvider} from "@gearbox-protocol/core-v3/contracts/interfaces/base/IAddressProvider.sol";
+
+/// @notice Configurable Midas data feed mock: returns a settable rate in base 18.
+contract AuditMidasDataFeed {
+    uint256 public rate;
+    bool public revertNextCall;
+
+    constructor(uint256 rate_) {
+        rate = rate_;
+    }
+
+    function setRate(uint256 r) external {
+        rate = r;
+    }
+
+    function setRevertNextCall(bool v) external {
+        revertNextCall = v;
+    }
+
+    function getDataInBase18() external view returns (uint256) {
+        if (revertNextCall) revert("dataFeed: view unavailable");
+        return rate;
+    }
+}
+
+/// @notice Configurable Midas issuance vault mock.
+///         Models: full pull of input, configurable mToken output, optional revert, optional access control.
+contract AuditMidasIssuanceVault {
+    address public immutable mToken;
+    address public accessControl;
+    uint256 public mTokenAmountOut;
+    bool public revertNextCall;
+
+    constructor(address mToken_) {
+        mToken = mToken_;
+    }
+
+    function setMTokenAmountOut(uint256 a) external {
+        mTokenAmountOut = a;
+    }
+
+    function setAccessControl(address ac) external {
+        accessControl = ac;
+    }
+
+    function setRevertNextCall(bool v) external {
+        revertNextCall = v;
+    }
+
+    function depositInstant(address tokenIn, uint256 amountTokenE18, uint256, bytes32) external {
+        if (revertNextCall) revert("issuance: unavailable");
+        uint256 nativeAmount = amountTokenE18 * 10 ** IERC20Metadata(tokenIn).decimals() / 1e18;
+        IERC20(tokenIn).transferFrom(msg.sender, address(this), nativeAmount);
+        IERC20(mToken).transfer(msg.sender, mTokenAmountOut);
+    }
+}
+
+/// @notice Configurable Midas redemption vault mock.
+///         Models: full pull of mToken on redeemRequest/redeemInstant, configurable output,
+///         settable per-request status/rates, optional view reverts, ID starting at 0 (upstream-faithful).
+contract AuditMidasRedemptionVault {
+    struct Request {
+        address sender;
+        address tokenOut;
+        uint8 status;
+        uint256 amountMTokenIn;
+        uint256 mTokenRate;
+        uint256 tokenOutRate;
+    }
+
+    address public immutable mToken;
+    address public immutable mTokenDataFeed;
+    address public accessControl;
+    uint256 public tokenOutAmount;
+    bool public redeemRequestsRevert;
+    bool public redeemInstantRevert;
+    bool public redeemRequestRevert;
+
+    uint256 public currentRequestId;
+    mapping(uint256 => Request) internal _requests;
+
+    constructor(address mToken_, address mTokenDataFeed_) {
+        mToken = mToken_;
+        mTokenDataFeed = mTokenDataFeed_;
+    }
+
+    function setTokenOutAmount(uint256 a) external {
+        tokenOutAmount = a;
+    }
+
+    function setAccessControl(address ac) external {
+        accessControl = ac;
+    }
+
+    function setRedeemRequestsRevert(bool v) external {
+        redeemRequestsRevert = v;
+    }
+
+    function setRedeemInstantRevert(bool v) external {
+        redeemInstantRevert = v;
+    }
+
+    function setRedeemRequestRevert(bool v) external {
+        redeemRequestRevert = v;
+    }
+
+    function redeemInstant(address tokenOut, uint256 amountMTokenIn, uint256) external {
+        if (redeemInstantRevert) revert("redeemInstant: unavailable");
+        IERC20(mToken).transferFrom(msg.sender, address(this), amountMTokenIn);
+        IERC20(tokenOut).transfer(msg.sender, tokenOutAmount);
+    }
+
+    function redeemRequest(address tokenOut, uint256 amountMTokenIn) external returns (uint256 requestId) {
+        if (redeemRequestRevert) revert("redeemRequest: unavailable");
+        IERC20(mToken).transferFrom(msg.sender, address(this), amountMTokenIn);
+        // Upstream-faithful: first request ID is 0, then increment.
+        requestId = currentRequestId;
+        _requests[requestId] = Request({
+            sender: msg.sender,
+            tokenOut: tokenOut,
+            status: 0,
+            amountMTokenIn: amountMTokenIn,
+            mTokenRate: 1e18,
+            tokenOutRate: 1e18
+        });
+        currentRequestId = requestId + 1;
+    }
+
+    function setStatus(uint256 requestId, uint8 status) external {
+        _requests[requestId].status = status;
+    }
+
+    function setRates(uint256 requestId, uint256 mTokenRate, uint256 tokenOutRate) external {
+        _requests[requestId].mTokenRate = mTokenRate;
+        _requests[requestId].tokenOutRate = tokenOutRate;
+    }
+
+    function redeemRequests(uint256 requestId)
+        external
+        view
+        returns (address, address, uint8, uint256, uint256, uint256)
+    {
+        if (redeemRequestsRevert) revert("redeemRequests: view unavailable");
+        Request memory r = _requests[requestId];
+        return (r.sender, r.tokenOut, r.status, r.amountMTokenIn, r.mTokenRate, r.tokenOutRate);
+    }
+}
+
+/// @notice Mock credit account exposing the contract type and a settable credit manager.
+///         Supports approving tokens so the gateway can pull via transferFrom.
+contract AuditCreditAccount {
+    bytes32 public constant contractType = "CREDIT_ACCOUNT";
+    uint256 public constant version = 3_10;
+
+    address public immutable creditManager;
+
+    constructor(address creditManager_) {
+        creditManager = creditManager_;
+    }
+
+    function approveToken(address token, address spender, uint256 amount) external {
+        IERC20(token).approve(spender, amount);
+    }
+}
+
+/// @notice Mock that returns a non-credit-account contract type.
+contract AuditNonCreditAccount {
+    bytes32 public constant contractType = "NOT_CREDIT_ACCOUNT";
+}
+
+/// @notice Minimal credit manager mock exposing borrower lookup, contractToAdapter mapping,
+///         a settable credit facade address, and a pullFrom helper that simulates the credit
+///         manager pulling tokens from a payer using its allowance (as in real addCollateral).
+contract AuditCreditManager {
+    mapping(address => address) internal _borrowers;
+    mapping(address => address) internal _adapterFor;
+    address public creditFacade;
+
+    function setBorrower(address creditAccount, address borrower) external {
+        _borrowers[creditAccount] = borrower;
+    }
+
+    function setAdapter(address target, address adapter) external {
+        _adapterFor[target] = adapter;
+    }
+
+    function setCreditFacade(address facade) external {
+        creditFacade = facade;
+    }
+
+    function creditAccountInfo(address creditAccount)
+        external
+        view
+        returns (uint256, uint256, uint128, uint128, uint256, uint16, uint64, address borrower)
+    {
+        borrower = _borrowers[creditAccount];
+        return (0, 0, 0, 0, 0, 0, 0, borrower);
+    }
+
+    function contractToAdapter(address target) external view returns (address) {
+        return _adapterFor[target];
+    }
+
+    /// @dev Simulates the credit manager pulling tokens from `payer` (using its allowance)
+    ///      and crediting them to `to`. Mirrors `ICreditManagerV3.addCollateral(payer, ...)`.
+    function pullFrom(address payer, address token, uint256 amount, address to) external {
+        IERC20(token).transferFrom(payer, to, amount);
+    }
+}
+
+/// @notice Minimal Midas access control mock supporting role grant/revoke/hasRole.
+contract AuditMidasAccessControl {
+    mapping(bytes32 => mapping(address => bool)) internal _roles;
+
+    function hasRole(bytes32 role, address account) external view returns (bool) {
+        return _roles[role][account];
+    }
+
+    function grantRole(bytes32 role, address account) external {
+        _roles[role][account] = true;
+    }
+
+    function revokeRole(bytes32 role, address account) external {
+        _roles[role][account] = false;
+    }
+}
+
+/// @notice Minimal AddressProvider mock that returns a settable redemption logger address
+///         for the AP_REDEMPTION_LOGGER key, mirroring the new gateway constructor behavior.
+contract AuditAddressProvider is IAddressProvider {
+    address internal _redemptionLogger;
+
+    constructor(address redemptionLogger_) {
+        _redemptionLogger = redemptionLogger_;
+    }
+
+    function setRedemptionLogger(address logger) external {
+        _redemptionLogger = logger;
+    }
+
+    function getAddressOrRevert(bytes32 key, uint256 version) external view returns (address) {
+        if (key == AP_REDEMPTION_LOGGER && version == 3_10) {
+            if (_redemptionLogger == address(0)) revert("AP: redemption logger not set");
+            return _redemptionLogger;
+        }
+        revert("AP: key not found");
+    }
+}
+
+/// @notice Minimal credit facade mock that records calls and can call back into adapters.
+///         Tracks the original multicaller (msg.sender of liquidateCreditAccount) so that
+///         addCollateral can pull from the liquidator via the credit manager, mirroring the
+///         real Gearbox flow where the facade pulls from the multicaller, not from itself.
+contract AuditCreditFacade {
+    address public immutable creditManager;
+    address[] public addCollateralTokens;
+    uint256[] public addCollateralAmounts;
+    bool public liquidateRevert;
+    address public multicaller;
+
+    constructor(address creditManager_) {
+        creditManager = creditManager_;
+    }
+
+    function setLiquidateRevert(bool v) external {
+        liquidateRevert = v;
+    }
+
+    function addCollateral(address token, uint256 amount) external {
+        addCollateralTokens.push(token);
+        addCollateralAmounts.push(amount);
+        // Pull from the tracked multicaller (the liquidator) via the credit manager,
+        // which has allowance from the liquidator's forceApprove during _forwardCollateral.
+        AuditCreditManager(creditManager).pullFrom(multicaller, token, amount, address(this));
+    }
+
+    function liquidateCreditAccount(address, address, MultiCall[] calldata calls, bytes memory) external {
+        if (liquidateRevert) revert("facade: liquidation unavailable");
+        multicaller = msg.sender;
+        for (uint256 i = 0; i < calls.length; i++) {
+            (bool ok,) = calls[i].target.call(calls[i].callData);
+            if (!ok) revert("facade: multicall step failed");
+        }
+        multicaller = address(0);
+    }
+
+    /// @dev Tolerated no-op selector used to test that _forwardCollateral ignores
+    ///      non-addCollateral calls that still target the facade.
+    function noop() external {}
+}
+
+/// @notice Shared base contract for Midas audit tests.
+abstract contract MidasAuditTestBase is Test {
+    uint256 internal constant REDEMPTION_DURATION = 1 days;
+    bytes32 internal constant REFERRER_ID = bytes32(uint256(0xC0FFEE));
+
+    AuditMidasDataFeed internal dataFeed;
+    AuditMidasIssuanceVault internal issuanceVault;
+    AuditMidasRedemptionVault internal redemptionVault;
+    AuditCreditManager internal creditManager;
+    AuditCreditAccount internal account;
+    AuditAddressProvider internal addressProvider;
+    MidasGateway internal gateway;
+    MidasLiquidator internal liquidator;
+    MidasRedemptionVaultPhantomToken internal phantomToken;
+
+    address internal mToken;
+    address internal quoteToken18;
+    address internal borrower;
+
+    function _deployGateway18(bool withDelayedWithdrawals, bool checkBorrowerGreenlist, address accessControl_)
+        internal
+    {
+        mToken = address(new ERC20Mock("mTBILL", "mTBILL", 18));
+        quoteToken18 = address(new ERC20Mock("DAI", "DAI", 18));
+        borrower = makeAddr("BORROWER");
+
+        dataFeed = new AuditMidasDataFeed(1e18);
+        issuanceVault = new AuditMidasIssuanceVault(mToken);
+        redemptionVault = new AuditMidasRedemptionVault(mToken, address(dataFeed));
+        creditManager = new AuditCreditManager();
+        // AddressProvider with no redemption logger by default; gateway constructor wraps the
+        // lookup in a try/catch so an unset logger yields redemptionLogger = address(0).
+        addressProvider = new AuditAddressProvider(address(0));
+
+        if (accessControl_ != address(0)) {
+            issuanceVault.setAccessControl(accessControl_);
+            redemptionVault.setAccessControl(accessControl_);
+        }
+
+        gateway = new MidasGateway(
+            address(issuanceVault),
+            address(redemptionVault),
+            quoteToken18,
+            accessControl_ != address(0),
+            address(0),
+            checkBorrowerGreenlist,
+            REDEMPTION_DURATION,
+            withDelayedWithdrawals,
+            address(addressProvider)
+        );
+
+        liquidator = MidasLiquidator(payable(gateway.transferMaster()));
+        if (withDelayedWithdrawals) {
+            phantomToken = MidasRedemptionVaultPhantomToken(gateway.phantomToken());
+        }
+
+        account = new AuditCreditAccount(address(creditManager));
+        creditManager.setBorrower(address(account), borrower);
+    }
+
+    /// @dev Sets `isTransferAllowed` on the gateway's liquidator by writing its slot 0.
+    function _setTransferAllowed(bool allowed) internal {
+        vm.store(address(liquidator), bytes32(uint256(0)), bytes32(uint256(allowed ? 1 : 0)));
+    }
+
+    /// @dev Funds the account with `amount` of mToken and approves the gateway to pull it.
+    function _fundAccountWithMToken(uint256 amount) internal {
+        deal(mToken, address(account), amount);
+        vm.prank(address(account));
+        account.approveToken(mToken, address(gateway), amount);
+    }
+
+    /// @dev Funds the account with `amount` of quote token and approves the gateway to pull it.
+    function _fundAccountWithQuote(uint256 amount) internal {
+        deal(quoteToken18, address(account), amount);
+        vm.prank(address(account));
+        account.approveToken(quoteToken18, address(gateway), amount);
+    }
+
+    /// @dev Requests a redemption from the account and returns the new redeemer address.
+    function _requestRedeemFromAccount(uint256 amountMTokenIn) internal returns (address redeemer) {
+        _fundAccountWithMToken(amountMTokenIn);
+        vm.prank(address(account));
+        gateway.requestRedeem(amountMTokenIn, "");
+        redeemer = gateway.pendingRedeemers(address(account))[0];
+    }
+}

--- a/contracts/test/audit/midas/MidasDecimalMath.fuzz.t.sol
+++ b/contracts/test/audit/midas/MidasDecimalMath.fuzz.t.sol
@@ -1,0 +1,291 @@
+// SPDX-License-Identifier: UNLICENSED
+// Gearbox Protocol. Generalized leverage for DeFi protocols
+// (c) Gearbox Foundation, 2026.
+pragma solidity ^0.8.23;
+
+import {Test} from "forge-std/Test.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {ERC20Mock} from "@gearbox-protocol/core-v3/contracts/test/mocks/token/ERC20Mock.sol";
+import {WAD, RAY} from "@gearbox-protocol/core-v3/contracts/libraries/Constants.sol";
+
+import {MidasRedeemer} from "../../../helpers/midas/MidasRedeemer.sol";
+import {MidasGateway} from "../../../helpers/midas/MidasGateway.sol";
+
+/// @notice Re-declaration of the redeemer math as a pure harness so it can be fuzzed without a vault.
+///         Mirrors `MidasRedeemer._calculateTokenOutAmount` exactly.
+contract RedeemerMathHarness {
+    function calcTokenOutAmount(uint256 amountMTokenIn, uint256 mTokenRate, uint256 tokenOutRate, uint8 quoteDecimals)
+        external
+        pure
+        returns (uint256)
+    {
+        uint256 amount1e18 = (amountMTokenIn * mTokenRate) / tokenOutRate;
+        uint256 tokenUnit = 10 ** quoteDecimals;
+        if (tokenUnit == WAD) return amount1e18;
+        return amount1e18 * tokenUnit / WAD;
+    }
+}
+
+/// @notice Re-declaration of `MidasGateway._convertToE18` as a pure harness for fuzzing.
+contract GatewayMathHarness {
+    function convertToE18(uint256 amount, uint8 quoteDecimals) external pure returns (uint256) {
+        uint256 tokenUnit = 10 ** quoteDecimals;
+        if (tokenUnit == WAD) return amount;
+        return amount * WAD / tokenUnit;
+    }
+}
+
+/// @title Midas decimal math fuzz tests
+/// @notice F:[MID-MATH]: Fuzz tests proving the precision, monotonicity, and bound properties
+///         of the Midas decimal conversion and pending-amount math.
+contract MidasDecimalMathFuzzTest is Test {
+    RedeemerMathHarness internal redeemerMath;
+    GatewayMathHarness internal gatewayMath;
+
+    function setUp() public {
+        redeemerMath = new RedeemerMathHarness();
+        gatewayMath = new GatewayMathHarness();
+    }
+
+    /*
+     * @test-id: tst_core_midas_020
+     * @scenario: scn_midas_convert_e18_exact
+     * @covers: contracts/helpers/midas/MidasGateway.sol::_convertToE18
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Test environment: pure math harness
+     * Clients: direct calls
+     * Mocks: none
+     * Data: fuzzed amounts and decimals in [0, 18]
+     *
+     * Invariant: _convertToE18 is exact for decimals d <= 18.
+     *            Proof: amount * 1e18 / 10^d = amount * 10^(18-d), which is an integer
+     *            multiplication (no division) for d <= 18, so the result is exact.
+     */
+    function testFuzz_tst_core_midas_020_convertToE18_is_exact_for_decimals_le_18(uint256 amount, uint8 d) public pure {
+        d = uint8(bound(uint256(d), 0, 18));
+        // bound amount so amount * 1e18 cannot overflow (covers all realistic token supplies)
+        amount = bound(amount, 0, type(uint256).max / WAD);
+        uint256 tokenUnit = 10 ** uint256(d);
+        // expected = amount * 10^(18-d) is an integer multiplication for d <= 18
+        uint256 expected = amount * (10 ** (18 - uint256(d)));
+        // the contract formula amount * 1e18 / 10^d must equal the exact integer product
+        assertEq(amount * WAD / tokenUnit, expected, "convertToE18 not exact for d <= 18");
+    }
+
+    /*
+     * @test-id: tst_core_midas_021
+     * @scenario: scn_midas_convert_e18_inverse
+     * @covers: contracts/helpers/midas/MidasGateway.sol::_convertToE18
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Test environment: pure math harness
+     * Clients: direct calls
+     * Mocks: none
+     * Data: fuzzed base-18 amounts and decimals in [0, 18]
+     *
+     * Invariant: convertToE18(amount) then converting back to native yields exactly `amount`
+     *            for d <= 18 (no round-trip loss), because 1e18 / 10^d is an integer.
+     */
+    function testFuzz_tst_core_midas_021_convertToE18_round_trip_is_lossless(uint256 amountNative, uint8 d) public {
+        d = uint8(bound(uint256(d), 0, 18));
+        uint256 tokenUnit = 10 ** uint256(d);
+        // amountNative * 1e18 must not overflow
+        amountNative = bound(amountNative, 0, type(uint256).max / WAD);
+        uint256 e18 = gatewayMath.convertToE18(amountNative, d);
+        // back to native: e18 * tokenUnit / 1e18 — for d <= 18 this is exact because
+        // e18 = amountNative * 10^(18-d), and e18 * 10^d / 1e18 = amountNative * 10^(18-d) * 10^d / 1e18 = amountNative
+        uint256 backNative = e18 * tokenUnit / WAD;
+        assertEq(backNative, amountNative, "round-trip loss for d <= 18");
+    }
+
+    /*
+     * @test-id: tst_core_midas_022
+     * @scenario: scn_midas_pending_amount_monotonic_in_mtoken_rate
+     * @covers: contracts/helpers/midas/MidasRedeemer.sol::pendingTokenOutAmount
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Test environment: pure math harness
+     * Clients: direct calls
+     * Mocks: none
+     * Data: fuzzed amountMTokenIn, tokenOutRate, two mToken rates
+     *
+     * Invariant: pendingTokenOutAmount is monotonically non-decreasing in mTokenRate.
+     *            Proof: f(r) = amountMTokenIn * r / tokenOutRate; partial derivative wrt r is
+     *            amountMTokenIn / tokenOutRate > 0 (for positive inputs), so f is strictly
+     *            increasing in r when integer division does not erase the difference.
+     */
+    function testFuzz_tst_core_midas_022_pending_amount_monotonic_in_mtoken_rate(
+        uint256 amountMTokenIn,
+        uint256 rateLow,
+        uint256 rateHigh,
+        uint256 tokenOutRate,
+        uint8 quoteDecimals
+    ) public {
+        tokenOutRate = bound(tokenOutRate, 1, 1e27);
+        // keep amountMTokenIn * mTokenRate within uint256 (1e30 * 1e27 = 1e57 < 2^256)
+        amountMTokenIn = bound(amountMTokenIn, 0, 1e30);
+        rateLow = bound(rateLow, 1, 1e27);
+        rateHigh = bound(rateHigh, rateLow, 1e27);
+        quoteDecimals = uint8(bound(uint256(quoteDecimals), 0, 18));
+
+        uint256 pendingLow = redeemerMath.calcTokenOutAmount(amountMTokenIn, rateLow, tokenOutRate, quoteDecimals);
+        uint256 pendingHigh = redeemerMath.calcTokenOutAmount(amountMTokenIn, rateHigh, tokenOutRate, quoteDecimals);
+        assertLe(pendingLow, pendingHigh, "pending amount must be non-decreasing in mTokenRate");
+    }
+
+    /*
+     * @test-id: tst_core_midas_023
+     * @scenario: scn_midas_pending_amount_precision_bound
+     * @covers: contracts/helpers/midas/MidasRedeemer.sol::_calculateTokenOutAmount
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Test environment: pure math harness
+     * Clients: direct calls
+     * Mocks: none
+     * Data: fuzzed amountMTokenIn, rates, decimals in [0, 18]
+     *
+     * Invariant: the rounding error of _calculateTokenOutAmount is strictly less than
+     *            1 unit of the quote token (i.e. < 10^decimals wei of the result).
+     *            Proof sketch: amount1e18 = (a * r) / s is exact up to <1 wei of 1e18.
+     *            Then result = amount1e18 * 10^d / 1e18 = amount1e18 / 10^(18-d). Integer
+     *            division rounds down by < 10^(18-d) wei of 1e18, which equals < 1 unit of
+     *            the d-decimal token. So |result - true| < 1 unit.
+     */
+    function testFuzz_tst_core_midas_023_pending_amount_error_less_than_one_unit(
+        uint256 amountMTokenIn,
+        uint256 mTokenRate,
+        uint256 tokenOutRate,
+        uint8 quoteDecimals
+    ) public {
+        tokenOutRate = bound(tokenOutRate, 1, 1e27);
+        mTokenRate = bound(mTokenRate, 1, 1e27);
+        // bound so amountMTokenIn * mTokenRate * tokenUnit cannot overflow uint256
+        // (1e30 * 1e27 * 1e18 = 1e75 < 2^256 ~ 1.16e77)
+        amountMTokenIn = bound(amountMTokenIn, 0, 1e30);
+        quoteDecimals = uint8(bound(uint256(quoteDecimals), 0, 18));
+
+        uint256 result = redeemerMath.calcTokenOutAmount(amountMTokenIn, mTokenRate, tokenOutRate, quoteDecimals);
+        // single-division reference: a * r * u / (s * WAD) — error strictly < 1 unit of quote token
+        uint256 ref = _singleDivRef(amountMTokenIn, mTokenRate, tokenOutRate, quoteDecimals);
+        uint256 oneUnit = 10 ** uint256(quoteDecimals);
+        // the contract rounds down twice, so result <= ref (single division rounds down once)
+        assertLe(result, ref, "double-division must not exceed single-division reference");
+        if (ref > result) {
+            assertLt(ref - result, oneUnit, "rounding error must be < 1 unit of quote token");
+        }
+    }
+
+    /*
+     * @test-id: tst_core_midas_024
+     * @scenario: scn_midas_pending_amount_zero_input
+     * @covers: contracts/helpers/midas/MidasRedeemer.sol::_calculateTokenOutAmount
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Test environment: pure math harness
+     * Clients: direct calls
+     * Mocks: none
+     * Data: fuzzed rates and decimals with zero amountMTokenIn
+     *
+     * Invariant: zero input yields zero output (no division-by-zero issues, no phantom value).
+     */
+    function testFuzz_tst_core_midas_024_pending_amount_zero_input_yields_zero_output(
+        uint256 mTokenRate,
+        uint256 tokenOutRate,
+        uint8 quoteDecimals
+    ) public {
+        tokenOutRate = bound(tokenOutRate, 1, 1e27);
+        mTokenRate = bound(mTokenRate, 1, 1e27);
+        quoteDecimals = uint8(bound(uint256(quoteDecimals), 0, 18));
+        uint256 result = redeemerMath.calcTokenOutAmount(0, mTokenRate, tokenOutRate, quoteDecimals);
+        assertEq(result, 0, "zero input must yield zero output");
+    }
+
+    /*
+     * @test-id: tst_core_midas_025
+     * @scenario: scn_midas_pending_amount_overflow_boundary
+     * @covers: contracts/helpers/midas/MidasRedeemer.sol::_calculateTokenOutAmount
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Test environment: pure math harness
+     * Clients: direct calls
+     * Mocks: none
+     * Data: boundary amounts just below the overflow threshold of `amountMTokenIn * mTokenRate`
+     *
+     * Invariant: for realistic mToken supplies (<= 1e40 base-18 units) and rates (<= 1e27),
+     *            the product `amountMTokenIn * mTokenRate` does not overflow uint256
+     *            (max ~1.15e77). 1e40 * 1e27 = 1e67 < 2^256. The fuzz bound keeps inputs
+     *            inside this safe envelope and asserts the computation matches the reference.
+     */
+    function testFuzz_tst_core_midas_025_pending_amount_no_overflow_for_realistic_inputs(
+        uint256 amountMTokenIn,
+        uint256 mTokenRate,
+        uint256 tokenOutRate,
+        uint8 quoteDecimals
+    ) public {
+        tokenOutRate = bound(tokenOutRate, 1, 1e21);
+        // mTokenRate is returned by getDataInBase18, so it is in 1e18 base; bound to 1e21 (1000x headroom)
+        mTokenRate = bound(mTokenRate, 1, 1e21);
+        // 1e30 mToken base-18 units = 1e12 tokens, far above any realistic supply
+        amountMTokenIn = bound(amountMTokenIn, 0, 1e30);
+        quoteDecimals = uint8(bound(uint256(quoteDecimals), 0, 18));
+
+        // must not revert for realistic inputs; product amountMTokenIn * mTokenRate <= 1e51,
+        // and amount1e18 * tokenUnit <= (1e51 / 1) * 1e18 = 1e69 < 2^256
+        uint256 result = redeemerMath.calcTokenOutAmount(amountMTokenIn, mTokenRate, tokenOutRate, quoteDecimals);
+        assertTrue(result <= type(uint256).max, "result must fit in uint256");
+    }
+
+    /*
+     * @test-id: tst_core_midas_026
+     * @scenario: scn_midas_deposit_min_receive_consistency
+     * @covers: contracts/adapters/midas/MidasGatewayAdapter.sol::depositInstantDiff
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Test environment: pure math harness
+     * Clients: direct calls
+     * Mocks: none
+     * Data: fuzzed balance, leftover, rateMinRAY
+     *
+     * Invariant: depositInstantDiff computes minReceiveAmount = amount * rateMinRAY / RAY
+     *            where amount = balance - leftover (only when balance > leftover, else no-op).
+     *            The minReceive is a non-negative lower bound that is <= amount * rateMinRAY / RAY.
+     */
+    function testFuzz_tst_core_midas_026_deposit_diff_min_receive_bound(
+        uint256 balance,
+        uint256 leftover,
+        uint256 rateMinRAY
+    ) public pure {
+        rateMinRAY = bound(rateMinRAY, 0, RAY);
+        if (balance <= leftover) {
+            // no-op path: nothing to assert beyond the adapter not reverting
+            return;
+        }
+        unchecked {
+            uint256 amount = balance - leftover;
+            uint256 minReceive = (amount * rateMinRAY) / RAY;
+            // minReceive is a lower bound on expected output expressed in the same units as `amount`
+            assertLe(minReceive, amount, "minReceive cannot exceed amount at rateMinRAY <= RAY");
+        }
+    }
+
+    /// @dev Single-division reference: (a * r * u) / (s * WAD). One integer division => error < 1 unit.
+    ///      Inputs must be bounded so a * r * u and s * WAD do not overflow uint256.
+    function _singleDivRef(uint256 amountMTokenIn, uint256 mTokenRate, uint256 tokenOutRate, uint8 quoteDecimals)
+        internal
+        pure
+        returns (uint256)
+    {
+        uint256 tokenUnit = 10 ** uint256(quoteDecimals);
+        uint256 numerator = amountMTokenIn * mTokenRate * tokenUnit;
+        uint256 denominator = tokenOutRate * WAD;
+        return numerator / denominator;
+    }
+}

--- a/contracts/test/audit/midas/MidasFindings.poc.t.sol
+++ b/contracts/test/audit/midas/MidasFindings.poc.t.sol
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: UNLICENSED
+// Gearbox Protocol. Generalized leverage for DeFi protocols
+// (c) Gearbox Foundation, 2026.
+pragma solidity ^0.8.23;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {MidasGateway} from "../../../helpers/midas/MidasGateway.sol";
+import {MidasRedeemer} from "../../../helpers/midas/MidasRedeemer.sol";
+import {MidasRedemptionVaultPhantomToken} from "../../../helpers/midas/MidasRedemptionVaultPhantomToken.sol";
+
+import "./MidasAuditTestBase.sol";
+
+/// @title Midas findings PoC tests
+/// @notice P:[MID-FIND]: Proof-of-concept tests for confirmed audit findings.
+contract MidasFindingsPoCTest is MidasAuditTestBase {
+    function setUp() public {
+        _deployGateway18(true, false, address(0));
+    }
+
+    /*
+     * @test-id: tst_core_midas_001
+     * @scenario: scn_midas_saved_rate_001
+     * @covers: contracts/helpers/midas/MidasRedemptionVaultPhantomToken.sol::balanceOf
+     *          contracts/helpers/midas/MidasRedeemer.sol::pendingTokenOutAmount
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Test environment: MidasGateway with configurable data feed
+     * Clients: direct calls
+     * Mocks: AuditMidasRedemptionVault, AuditMidasDataFeed
+     * Data: 100e18 mToken request, mToken rate doubles after request
+     *
+     * Finding MID-R01: phantom uses the CURRENT mToken data feed rate, while Midas may settle
+     * at the request-time SAVED rate. When the mToken rate appreciates, the phantom balance
+     * exceeds the amount Midas will actually deliver, inflating borrowing capacity.
+     */
+    function test_tst_core_midas_001_phantom_overvalues_when_mtoken_rate_grows_vs_saved_rate() public {
+        uint256 amountMTokenIn = 100e18;
+        address redeemer = _requestRedeemFromAccount(amountMTokenIn);
+
+        assertEq(phantomToken.balanceOf(address(account)), 100e18, "initial phantom value");
+
+        // mToken rate doubles; tokenOutRate stays snapshotted at 1e18.
+        dataFeed.setRate(2e18);
+        assertEq(phantomToken.balanceOf(address(account)), 200e18, "phantom grows with current rate");
+
+        // Saved-rate settlement (what Midas would deliver if it settles at request-time rates):
+        // stored mTokenRate = 1e18, stored tokenOutRate = 1e18 => 100e18 quote only.
+        (,,, uint256 storedAmount, uint256 storedMTokenRate, uint256 storedTokenOutRate) =
+            redemptionVault.redeemRequests(MidasRedeemer(redeemer).requestId());
+        uint256 savedRateSettlement = (storedAmount * storedMTokenRate) / storedTokenOutRate;
+        assertEq(savedRateSettlement, 100e18, "saved-rate settlement is only 100e18");
+        assertGt(
+            phantomToken.balanceOf(address(account)),
+            savedRateSettlement,
+            "phantom overstates realizable settlement (MID-R01)"
+        );
+    }
+
+    /*
+     * @test-id: tst_core_midas_002
+     * @scenario: scn_midas_cancel_001
+     * @covers: contracts/helpers/midas/MidasRedeemer.sol::pendingTokenOutAmount
+     *          contracts/helpers/midas/MidasRedemptionVaultPhantomToken.sol::balanceOf
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Finding MID-R02: when Midas cancels a request (status = 2) without returning the mToken
+     * and without anyone manually clearing it, the phantom still reports the full projected
+     * value. The credit account can borrow against collateral with no enforceable recovery.
+     */
+    function test_tst_core_midas_002_cancelled_request_retains_unbacked_phantom_value() public {
+        uint256 amountMTokenIn = 100e18;
+        address redeemer = _requestRedeemFromAccount(amountMTokenIn);
+
+        // mToken has left the redeemer and is held by the vault
+        assertEq(IERC20(mToken).balanceOf(redeemer), 0, "mToken already pulled by vault");
+        assertEq(IERC20(mToken).balanceOf(address(redemptionVault)), amountMTokenIn, "vault holds the mToken");
+
+        // Midas rejects the request: status -> Canceled (2). No quote is sent to the redeemer.
+        redemptionVault.setStatus(0, 2);
+
+        assertEq(IERC20(quoteToken18).balanceOf(redeemer), 0, "redeemer holds no quote token");
+
+        uint256 phantomValue = phantomToken.balanceOf(address(account));
+        assertGt(phantomValue, 0, "phantom retains value after cancellation (MID-R02)");
+        assertEq(phantomValue, 100e18, "phantom reports full projected value with no backing asset");
+        assertFalse(MidasRedeemer(redeemer).isManuallyCleared(), "no manual clearing has occurred");
+    }
+
+    /*
+     * @test-id: tst_core_midas_007
+     * @scenario: scn_midas_transfer_cap_001
+     * @covers: contracts/helpers/midas/MidasGateway.sol::transferRedeemer
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Finding MID-R06: transferRedeemer does not check the 10-pending cap on the destination.
+     * Repeated transfers can push an account above MAX_PENDING_REDEEMERS_PER_ACCOUNT, causing
+     * unbounded gas in withdraw / pendingAndClaimableTokenOutAmounts.
+     */
+    function test_tst_core_midas_007_transfer_can_exceed_max_pending_redeemers_on_destination() public {
+        AuditCreditAccount accountB = new AuditCreditAccount(address(creditManager));
+        creditManager.setBorrower(address(accountB), makeAddr("BORROWER_B"));
+
+        // Give B one pending redeemer so B starts at 1/10.
+        deal(mToken, address(accountB), 1e18);
+        vm.prank(address(accountB));
+        accountB.approveToken(mToken, address(gateway), 1e18);
+        vm.prank(address(accountB));
+        gateway.requestRedeem(1e18, "");
+        assertEq(gateway.pendingRedeemers(address(accountB)).length, 1, "B starts with 1 redeemer");
+
+        // Create 10 redeemers on A (the maximum allowed by the creation cap).
+        _fundAccountWithMToken(10 * 1e18);
+        vm.startPrank(address(account));
+        for (uint256 i = 0; i < 10; i++) {
+            gateway.requestRedeem(1e18, "");
+        }
+        vm.stopPrank();
+        assertEq(gateway.pendingRedeemers(address(account)).length, 10, "A is at the 10 cap");
+
+        // Enable transfers (simulating a liquidation window).
+        _setTransferAllowed(true);
+
+        // Transfer all 10 of A's redeemers to B — cap is NOT checked on the destination.
+        address[] memory aRedeemers = gateway.pendingRedeemers(address(account));
+        vm.startPrank(address(account));
+        for (uint256 i = 0; i < aRedeemers.length; i++) {
+            gateway.transferRedeemer(aRedeemers[i], address(accountB));
+        }
+        vm.stopPrank();
+
+        assertGt(
+            gateway.pendingRedeemers(address(accountB)).length,
+            10,
+            "destination cap not enforced on transfer (MID-R06)"
+        );
+        assertEq(gateway.pendingRedeemers(address(accountB)).length, 11, "B has 11 pending redeemers");
+    }
+
+    /*
+     * @test-id: tst_core_midas_010
+     * @scenario: scn_midas_transfer_scope_001
+     * @covers: contracts/helpers/midas/MidasGateway.sol::transferRedeemer
+     *          contracts/helpers/midas/MidasLiquidator.sol::isTransferAllowed
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Finding MID-R09: isTransferAllowed is a single global boolean, not scoped to the account
+     * being liquidated. While account A's liquidation raises the flag, any other eligible
+     * account B can transfer its own redeemers to a new account even though B is not under
+     * liquidation, letting a borrower move positions outside a liquidation window.
+     */
+    function test_tst_core_midas_010_transfer_flag_is_global_not_scoped_to_liquidated_account() public {
+        _requestRedeemFromAccount(50e18);
+
+        // Account B is a separate, healthy credit account with its own redeemer.
+        AuditCreditAccount accountB = new AuditCreditAccount(address(creditManager));
+        creditManager.setBorrower(address(accountB), makeAddr("BORROWER_B"));
+        deal(mToken, address(accountB), 50e18);
+        vm.prank(address(accountB));
+        accountB.approveToken(mToken, address(gateway), 50e18);
+        vm.prank(address(accountB));
+        gateway.requestRedeem(50e18, "");
+        address redeemerB = gateway.pendingRedeemers(address(accountB))[0];
+
+        // Simulate account A's liquidation raising the global transfer flag.
+        _setTransferAllowed(true);
+
+        // Account B (NOT being liquidated) transfers its own redeemer to a brand-new account.
+        AuditCreditAccount accountC = new AuditCreditAccount(address(creditManager));
+        creditManager.setBorrower(address(accountC), makeAddr("BORROWER_C"));
+
+        vm.prank(address(accountB));
+        gateway.transferRedeemer(redeemerB, address(accountC));
+
+        assertEq(gateway.pendingRedeemers(address(accountB)).length, 0, "B's redeemer was transferred out");
+        assertEq(gateway.pendingRedeemers(address(accountC)).length, 1, "C received B's redeemer (MID-R09)");
+        assertEq(MidasRedeemer(redeemerB).account(), address(accountC), "redeemer account updated to C");
+    }
+
+    /*
+     * @test-id: tst_core_midas_012
+     * @scenario: scn_midas_status_001
+     * @covers: contracts/helpers/midas/MidasRedeemer.sol::pendingTokenOutAmount
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Finding MID-R10: pendingTokenOutAmount only treats status == 1 (Processed) and
+     * isManuallyCleared as terminal. Any other status (including Cancel=2 and unknown future
+     * values) is treated as pending and valued at the live mToken rate. A future Midas status
+     * meaning "no value" would keep reporting phantom collateral until manual intervention.
+     */
+    function test_tst_core_midas_012_unknown_status_treated_as_pending_and_overvalued() public {
+        uint256 amountMTokenIn = 100e18;
+        address redeemer = _requestRedeemFromAccount(amountMTokenIn);
+
+        // Simulate a future Midas status value (e.g. 99 = "Failed/Revoked").
+        redemptionVault.setStatus(0, 99);
+
+        uint256 pending = MidasRedeemer(redeemer).pendingTokenOutAmount();
+        assertGt(pending, 0, "unknown status still valued as pending (MID-R10)");
+        assertEq(pending, 100e18, "unknown status valued at full live-rate amount");
+
+        // Phantom follows the same path, so collateral value stays positive.
+        assertGt(phantomToken.balanceOf(address(account)), 0, "phantom reports value for unknown status");
+    }
+
+    /*
+     * @test-id: tst_core_midas_018
+     * @scenario: scn_midas_sweep_donation_001
+     * @covers: contracts/helpers/midas/MidasGateway.sol::_sweepTokens
+     *          contracts/helpers/midas/MidasGateway.sol::depositInstant
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Test environment: MidasGateway with a pre-existing donated quote-token balance
+     * Clients: direct calls
+     * Mocks: AuditMidasIssuanceVault, AuditMidasRedemptionVault
+     * Data: 50e18 donated quote, 10e18 deposit
+     *
+     * NEW FINDING (introduced by the sweeping fix in 7eaa0db): `_sweepTokens` transfers the
+     * ENTIRE gateway balance of both tokens, not just the balance delta produced by the current
+     * operation. The old code used `balanceAfter - balanceBefore` which was safe against
+     * pre-existing balances. The new code sweeps any pre-existing balance (donation, dust from
+     * a prior operation, or residual from a reverted sub-call) to the current caller.
+     *
+     * If an attacker donates quote tokens to the gateway, the next credit account that calls
+     * `depositInstant` receives the donated amount on top of its normal mToken output.
+     * Symmetrically, a donated mToken balance is swept to the next `redeemInstant` caller.
+     */
+    function test_tst_core_midas_018_sweeptokens_sweeps_preexisting_donation_to_next_caller() public {
+        // 1. Donate 50e18 quote to the gateway (simulates a prior donation or stranded dust).
+        uint256 donation = 50e18;
+        deal(quoteToken18, address(gateway), donation);
+
+        // 2. Account deposits 10e18 quote; vault issues 10e18 mToken (1:1).
+        uint256 depositAmount = 10e18;
+        _fundAccountWithQuote(depositAmount);
+        deal(mToken, address(issuanceVault), 10e18);
+        issuanceVault.setMTokenAmountOut(10e18);
+
+        uint256 accountQuoteBefore = IERC20(quoteToken18).balanceOf(address(account));
+        vm.prank(address(account));
+        gateway.depositInstant(depositAmount, 0, bytes32(0));
+
+        // 3. The account received the 10e18 mToken output...
+        assertEq(IERC20(mToken).balanceOf(address(account)), 10e18, "account received mToken output");
+
+        // 4. ...AND the 50e18 donated quote, because _sweepTokens sweeps the entire balance.
+        //    The account spent 10e18 quote on the deposit, but got 50e18 back from the sweep.
+        uint256 accountQuoteAfter = IERC20(quoteToken18).balanceOf(address(account));
+        assertEq(accountQuoteAfter + depositAmount - accountQuoteBefore, donation, "account swept the donated quote (new finding)");
+        assertEq(IERC20(quoteToken18).balanceOf(address(gateway)), 0, "gateway fully drained");
+
+        // The donation was moved from the gateway to the caller's credit account. Under the
+        // old balance-delta accounting, the donation would have stayed on the gateway.
+    }
+
+    /*
+     * @test-id: tst_core_midas_019
+     * @scenario: scn_midas_sweep_donation_002
+     * @covers: contracts/helpers/midas/MidasGateway.sol::_sweepTokens
+     *          contracts/helpers/midas/MidasGateway.sol::redeemInstant
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Test environment: MidasGateway with a pre-existing donated mToken balance
+     * Clients: direct calls
+     * Mocks: AuditMidasRedemptionVault
+     * Data: 50e18 donated mToken, 10e18 instant redemption
+     *
+     * NEW FINDING (symmetric to 018): a donated mToken balance is swept to the next
+     * `redeemInstant` caller on top of their normal quote-token output.
+     */
+    function test_tst_core_midas_019_sweeptokens_sweeps_preexisting_mtoken_donation_to_next_caller() public {
+        // 1. Donate 50e18 mToken to the gateway.
+        uint256 donation = 50e18;
+        deal(mToken, address(gateway), donation);
+
+        // 2. Account instant-redeems 10e18 mToken; vault sends 10e18 quote (1:1).
+        _fundAccountWithMToken(10e18);
+        deal(quoteToken18, address(redemptionVault), 10e18);
+        redemptionVault.setTokenOutAmount(10e18);
+
+        uint256 accountMTokenBefore = IERC20(mToken).balanceOf(address(account));
+        vm.prank(address(account));
+        gateway.redeemInstant(10e18, 0);
+
+        // 3. The account received the 10e18 quote output...
+        assertEq(IERC20(quoteToken18).balanceOf(address(account)), 10e18, "account received quote output");
+
+        // 4. ...AND the 50e18 donated mToken, because _sweepTokens sweeps the entire mToken balance.
+        //    The account spent 10e18 mToken on the redemption, but got 50e18 back from the sweep.
+        uint256 accountMTokenAfter = IERC20(mToken).balanceOf(address(account));
+        assertEq(accountMTokenAfter + 10e18 - accountMTokenBefore, donation, "account swept the donated mToken (new finding)");
+        assertEq(IERC20(mToken).balanceOf(address(gateway)), 0, "gateway fully drained");
+    }
+}

--- a/contracts/test/audit/midas/MidasGatewayResiduals.poc.t.sol
+++ b/contracts/test/audit/midas/MidasGatewayResiduals.poc.t.sol
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: UNLICENSED
+// Gearbox Protocol. Generalized leverage for DeFi protocols
+// (c) Gearbox Foundation, 2026.
+pragma solidity ^0.8.23;
+
+import {Test} from "forge-std/Test.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {ERC20Mock} from "@gearbox-protocol/core-v3/contracts/test/mocks/token/ERC20Mock.sol";
+
+import {MidasGateway} from "../../../helpers/midas/MidasGateway.sol";
+
+contract PartialSpendMidasDataFeedMock {
+    function getDataInBase18() external pure returns (uint256) {
+        return 1e18;
+    }
+}
+
+contract PartialSpendMidasIssuanceVaultMock {
+    address public immutable mToken;
+    address public accessControl;
+    uint256 public immutable spendBps;
+    uint256 public mTokenAmountOut;
+
+    constructor(address mToken_, uint256 spendBps_) {
+        mToken = mToken_;
+        spendBps = spendBps_;
+    }
+
+    function setMTokenAmountOut(uint256 amount) external {
+        mTokenAmountOut = amount;
+    }
+
+    function depositInstant(address tokenIn, uint256 amountToken, uint256, bytes32) external {
+        uint256 nativeAmount = amountToken * 10 ** IERC20Metadata(tokenIn).decimals() / 1e18;
+        IERC20(tokenIn).transferFrom(msg.sender, address(this), nativeAmount * spendBps / 10_000);
+        IERC20(mToken).transfer(msg.sender, mTokenAmountOut);
+    }
+}
+
+contract PartialSpendMidasRedemptionVaultMock {
+    struct Request {
+        address sender;
+        address tokenOut;
+        uint8 status;
+        uint256 amountMTokenIn;
+        uint256 mTokenRate;
+        uint256 tokenOutRate;
+    }
+
+    address public immutable mToken;
+    address public immutable mTokenDataFeed;
+    address public accessControl;
+    uint256 public immutable spendBps;
+    uint256 public tokenOutAmount;
+    uint256 public currentRequestId;
+    mapping(uint256 => Request) internal _requests;
+
+    constructor(address mToken_, address mTokenDataFeed_, uint256 spendBps_) {
+        mToken = mToken_;
+        mTokenDataFeed = mTokenDataFeed_;
+        spendBps = spendBps_;
+    }
+
+    function setTokenOutAmount(uint256 amount) external {
+        tokenOutAmount = amount;
+    }
+
+    function redeemInstant(address tokenOut, uint256 amountMTokenIn, uint256) external {
+        IERC20(mToken).transferFrom(msg.sender, address(this), amountMTokenIn * spendBps / 10_000);
+        IERC20(tokenOut).transfer(msg.sender, tokenOutAmount);
+    }
+
+    function redeemRequest(address tokenOut, uint256 amountMTokenIn) external returns (uint256 requestId) {
+        IERC20(mToken).transferFrom(msg.sender, address(this), amountMTokenIn * spendBps / 10_000);
+
+        requestId = currentRequestId++;
+        _requests[requestId] = Request({
+            sender: msg.sender,
+            tokenOut: tokenOut,
+            status: 0,
+            amountMTokenIn: amountMTokenIn,
+            mTokenRate: 1e18,
+            tokenOutRate: 1e18
+        });
+    }
+
+    function redeemRequests(uint256 requestId)
+        external
+        view
+        returns (address, address, uint8, uint256, uint256, uint256)
+    {
+        Request memory request = _requests[requestId];
+        return (
+            request.sender,
+            request.tokenOut,
+            request.status,
+            request.amountMTokenIn,
+            request.mTokenRate,
+            request.tokenOutRate
+        );
+    }
+}
+
+contract PartialSpendCreditManagerMock {
+    mapping(address => address) internal _borrowers;
+
+    function setBorrower(address creditAccount, address borrower) external {
+        _borrowers[creditAccount] = borrower;
+    }
+
+    function creditAccountInfo(address creditAccount)
+        external
+        view
+        returns (uint256, uint256, uint128, uint128, uint256, uint16, uint64, address borrower)
+    {
+        borrower = _borrowers[creditAccount];
+        return (0, 0, 0, 0, 0, 0, 0, borrower);
+    }
+}
+
+/// @dev Minimal AddressProvider mock returning address(0) for the redemption logger key,
+///      mirroring the upstream test helper. Used so the residual-input PoC gateway can be
+///      constructed with the new addressProvider parameter without tracking a real logger.
+contract PartialSpendAddressProviderMock {
+    function getAddressOrRevert(bytes32, uint256) external pure returns (address) {
+        return address(0);
+    }
+}
+
+contract PartialSpendCreditAccountMock {
+    bytes32 public constant contractType = "CREDIT_ACCOUNT";
+    uint256 public constant version = 3_10;
+
+    address public immutable creditManager;
+
+    constructor(address creditManager_) {
+        creditManager = creditManager_;
+    }
+
+    function approveToken(address token, address spender, uint256 amount) external {
+        IERC20(token).approve(spender, amount);
+    }
+}
+
+/// @title Midas gateway residual-input security PoCs
+/// @notice RED tests for successful Midas calls that consume less input than requested.
+contract MidasGatewayResidualsPoCTest is Test {
+    uint256 internal constant SPEND_BPS = 6_000;
+    uint256 internal constant AMOUNT_IN = 100e18;
+
+    address internal mToken;
+    address internal quoteToken;
+    PartialSpendMidasIssuanceVaultMock internal issuanceVault;
+    PartialSpendMidasRedemptionVaultMock internal redemptionVault;
+    PartialSpendCreditManagerMock internal creditManager;
+    PartialSpendCreditAccountMock internal account;
+    MidasGateway internal gateway;
+
+    function setUp() public {
+        mToken = address(new ERC20Mock("mToken", "MT", 18));
+        quoteToken = address(new ERC20Mock("Quote", "QUOTE", 18));
+
+        PartialSpendMidasDataFeedMock dataFeed = new PartialSpendMidasDataFeedMock();
+        issuanceVault = new PartialSpendMidasIssuanceVaultMock(mToken, SPEND_BPS);
+        redemptionVault = new PartialSpendMidasRedemptionVaultMock(mToken, address(dataFeed), SPEND_BPS);
+        creditManager = new PartialSpendCreditManagerMock();
+        PartialSpendAddressProviderMock addressProvider = new PartialSpendAddressProviderMock();
+
+        gateway = new MidasGateway(
+            address(issuanceVault),
+            address(redemptionVault),
+            quoteToken,
+            false,
+            address(0),
+            false,
+            1 days,
+            true, // withDelayedWithdrawals
+            address(addressProvider)
+        );
+
+        account = new PartialSpendCreditAccountMock(address(creditManager));
+        creditManager.setBorrower(address(account), makeAddr("BORROWER"));
+    }
+
+    /*
+     * @test-id: tst_core_midas_015
+     * @scenario: scn_midas_partial_input_001
+     * @covers: contracts/helpers/midas/MidasGateway.sol::depositInstant
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Test environment: MidasGateway with a deterministic partial-spend issuance vault
+     * Clients: direct calls
+     * Mocks: partial-spend Midas vaults and minimal Credit Account/Credit Manager
+     * Data: fixed 60% input spend
+     */
+    function test_tst_core_midas_015_deposit_refunds_unspent_quote_token() public {
+        deal(quoteToken, address(account), AMOUNT_IN);
+        account.approveToken(quoteToken, address(gateway), AMOUNT_IN);
+        deal(mToken, address(issuanceVault), AMOUNT_IN);
+        issuanceVault.setMTokenAmountOut(60e18);
+
+        vm.prank(address(account));
+        gateway.depositInstant(AMOUNT_IN, 0, bytes32(0));
+
+        assertEq(IERC20(quoteToken).balanceOf(address(gateway)), 0, "unspent quote token remains in gateway");
+    }
+
+    /*
+     * @test-id: tst_core_midas_016
+     * @scenario: scn_midas_partial_input_002
+     * @covers: contracts/helpers/midas/MidasGateway.sol::redeemInstant
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Test environment: MidasGateway with a deterministic partial-spend redemption vault
+     * Clients: direct calls
+     * Mocks: partial-spend Midas vaults and minimal Credit Account/Credit Manager
+     * Data: fixed 60% input spend
+     */
+    function test_tst_core_midas_016_instant_redemption_refunds_unspent_mtoken() public {
+        deal(mToken, address(account), AMOUNT_IN);
+        account.approveToken(mToken, address(gateway), AMOUNT_IN);
+        deal(quoteToken, address(redemptionVault), AMOUNT_IN);
+        redemptionVault.setTokenOutAmount(60e18);
+
+        vm.prank(address(account));
+        gateway.redeemInstant(AMOUNT_IN, 0);
+
+        assertEq(IERC20(mToken).balanceOf(address(gateway)), 0, "unspent mToken remains in gateway");
+    }
+
+    /*
+     * @test-id: tst_core_midas_017
+     * @scenario: scn_midas_partial_input_003
+     * @covers: contracts/helpers/midas/MidasRedeemer.sol::requestRedeem
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Test environment: MidasGateway with a deterministic partial-spend redemption vault
+     * Clients: direct calls
+     * Mocks: partial-spend Midas vaults and minimal Credit Account/Credit Manager
+     * Data: fixed 60% input spend
+     */
+    function test_tst_core_midas_017_delayed_redemption_refunds_unspent_mtoken() public {
+        deal(mToken, address(account), AMOUNT_IN);
+        account.approveToken(mToken, address(gateway), AMOUNT_IN);
+
+        vm.prank(address(account));
+        gateway.requestRedeem(AMOUNT_IN, "");
+
+        address redeemer = gateway.pendingRedeemers(address(account))[0];
+        assertEq(IERC20(mToken).balanceOf(redeemer), 0, "unspent mToken remains in redeemer");
+    }
+}

--- a/contracts/test/audit/midas/MidasLiquidator.unit.t.sol
+++ b/contracts/test/audit/midas/MidasLiquidator.unit.t.sol
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: UNLICENSED
+// Gearbox Protocol. Generalized leverage for DeFi protocols
+// (c) Gearbox Foundation, 2026.
+pragma solidity ^0.8.23;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ERC20Mock} from "@gearbox-protocol/core-v3/contracts/test/mocks/token/ERC20Mock.sol";
+import {MultiCall} from "@gearbox-protocol/core-v3/contracts/interfaces/ICreditFacadeV3.sol";
+import {ICreditFacadeV3Multicall} from "@gearbox-protocol/core-v3/contracts/interfaces/ICreditFacadeV3Multicall.sol";
+
+import {MidasGateway} from "../../../helpers/midas/MidasGateway.sol";
+import {MidasLiquidator} from "../../../helpers/midas/MidasLiquidator.sol";
+import {IMidasLiquidator} from "../../../interfaces/midas/IMidasLiquidator.sol";
+
+import "./MidasAuditTestBase.sol";
+
+/// @title Midas liquidator unit tests
+/// @notice U:[MID-LIQ]: Unit tests for MidasLiquidator, which currently has zero coverage.
+///         Covers collateral forwarding, transfer-flag lifecycle, validation reverts, and
+///         the residual-sweep finding (MID-R15).
+contract MidasLiquidatorUnitTest is MidasAuditTestBase {
+    AuditCreditFacade internal facade;
+    address internal collateralToken;
+    address internal otherToken;
+    address internal liquidatorEOA;
+
+    function setUp() public {
+        _deployGateway18(true, false, address(0));
+
+        facade = new AuditCreditFacade(address(creditManager));
+        creditManager.setCreditFacade(address(facade));
+        creditManager.setAdapter(address(gateway), makeAddr("ADAPTER"));
+
+        collateralToken = address(new ERC20Mock("COLL", "COLL", 18));
+        otherToken = address(new ERC20Mock("OTHER", "OTHER", 6));
+        liquidatorEOA = makeAddr("LIQUIDATOR_EOA");
+    }
+
+    function _addCollateralCall(address token, uint256 amount) internal view returns (MultiCall memory) {
+        return MultiCall({
+            target: msg.sender, // placeholder, overwritten by caller
+            callData: abi.encodeCall(ICreditFacadeV3Multicall.addCollateral, (token, amount))
+        });
+    }
+
+    function noop() external pure {}
+
+    /*
+     * @test-id: tst_core_midas_040
+     * @scenario: scn_midas_liq_forward_001
+     * @covers: contracts/helpers/midas/MidasLiquidator.sol::liquidateWithRedeemerTransfers
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Invariant inv_mid_liq_02: a single addCollateral call is pre-funded from the liquidator
+     * EOA, approved to the credit manager, consumed by the facade, and no leftover remains.
+     */
+    function test_tst_core_midas_040_single_addcollateral_is_forwarded_and_consumed() public {
+        uint256 amount = 100e18;
+        deal(collateralToken, liquidatorEOA, amount);
+
+        MultiCall[] memory calls = new MultiCall[](1);
+        calls[0] = MultiCall({
+            target: address(facade),
+            callData: abi.encodeCall(ICreditFacadeV3Multicall.addCollateral, (collateralToken, amount))
+        });
+
+        vm.startPrank(liquidatorEOA);
+        IERC20(collateralToken).approve(address(liquidator), amount);
+        liquidator.liquidateWithRedeemerTransfers(address(account), address(gateway), calls, "");
+        vm.stopPrank();
+
+        assertEq(IERC20(collateralToken).balanceOf(liquidatorEOA), 0, "EOA funded the full amount");
+        assertEq(IERC20(collateralToken).balanceOf(address(liquidator)), 0, "liquidator holds no residual");
+        assertEq(IERC20(collateralToken).balanceOf(address(facade)), amount, "facade received the collateral");
+        assertEq(IERC20(collateralToken).allowance(address(liquidator), address(creditManager)), 0, "allowance reset");
+        assertFalse(liquidator.isTransferAllowed(), "transfer flag reset after call");
+    }
+
+    /*
+     * @test-id: tst_core_midas_041
+     * @scenario: scn_midas_liq_forward_002
+     * @covers: contracts/helpers/midas/MidasLiquidator.sol::_forwardCollateral
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Invariant: multiple addCollateral calls with different tokens are all pre-funded and
+     * consumed; the transfer flag is raised exactly during the facade call.
+     */
+    function test_tst_core_midas_041_multiple_addcollateral_different_tokens() public {
+        uint256 amtA = 100e18;
+        uint256 amtB = 50e6;
+        deal(collateralToken, liquidatorEOA, amtA);
+        deal(otherToken, liquidatorEOA, amtB);
+
+        MultiCall[] memory calls = new MultiCall[](2);
+        calls[0] = MultiCall({
+            target: address(facade),
+            callData: abi.encodeCall(ICreditFacadeV3Multicall.addCollateral, (collateralToken, amtA))
+        });
+        calls[1] = MultiCall({
+            target: address(facade),
+            callData: abi.encodeCall(ICreditFacadeV3Multicall.addCollateral, (otherToken, amtB))
+        });
+
+        vm.startPrank(liquidatorEOA);
+        IERC20(collateralToken).approve(address(liquidator), amtA);
+        IERC20(otherToken).approve(address(liquidator), amtB);
+        liquidator.liquidateWithRedeemerTransfers(address(account), address(gateway), calls, "");
+        vm.stopPrank();
+
+        assertEq(IERC20(collateralToken).balanceOf(address(facade)), amtA, "facade received COLL");
+        assertEq(IERC20(otherToken).balanceOf(address(facade)), amtB, "facade received OTHER");
+        assertEq(IERC20(collateralToken).balanceOf(address(liquidator)), 0, "no COLL residual");
+        assertEq(IERC20(otherToken).balanceOf(address(liquidator)), 0, "no OTHER residual");
+    }
+
+    /*
+     * @test-id: tst_core_midas_042
+     * @scenario: scn_midas_liq_revert_transfer_master_001
+     * @covers: contracts/helpers/midas/MidasLiquidator.sol::liquidateWithRedeemerTransfers
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Invariant inv_mid_liq_01: reverts when the gateway's transferMaster is not this liquidator.
+     */
+    function test_tst_core_midas_042_reverts_when_transfer_master_mismatches() public {
+        // Deploy a different gateway whose transferMaster is a different liquidator.
+        AuditMidasIssuanceVault otherIssuance = new AuditMidasIssuanceVault(mToken);
+        AuditMidasRedemptionVault otherRedemption = new AuditMidasRedemptionVault(mToken, address(dataFeed));
+        MidasGateway otherGateway = new MidasGateway(
+            address(otherIssuance), address(otherRedemption), quoteToken18, false, address(0), false, 1 days, true, address(addressProvider)
+        );
+
+        MultiCall[] memory calls = new MultiCall[](0);
+        vm.expectRevert(IMidasLiquidator.NotValidGatewayException.selector);
+        vm.prank(liquidatorEOA);
+        liquidator.liquidateWithRedeemerTransfers(address(account), address(otherGateway), calls, "");
+    }
+
+    /*
+     * @test-id: tst_core_midas_043
+     * @scenario: scn_midas_liq_revert_no_adapter_001
+     * @covers: contracts/helpers/midas/MidasLiquidator.sol::liquidateWithRedeemerTransfers
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Invariant: reverts when the gateway has no registered adapter in the credit manager.
+     */
+    function test_tst_core_midas_043_reverts_when_gateway_has_no_adapter() public {
+        creditManager.setAdapter(address(gateway), address(0));
+        MultiCall[] memory calls = new MultiCall[](0);
+        vm.expectRevert(IMidasLiquidator.NotValidGatewayException.selector);
+        vm.prank(liquidatorEOA);
+        liquidator.liquidateWithRedeemerTransfers(address(account), address(gateway), calls, "");
+    }
+
+    /*
+     * @test-id: tst_core_midas_044
+     * @scenario: scn_midas_liq_flag_lifecycle_001
+     * @covers: contracts/helpers/midas/MidasLiquidator.sol::isTransferAllowed
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Invariant: isTransferAllowed is true only during the facade call and reset to false
+     * afterwards, even when the facade call reverts (state is rolled back).
+     */
+    function test_tst_core_midas_044_transfer_flag_reset_after_reverting_liquidation() public {
+        facade.setLiquidateRevert(true);
+        MultiCall[] memory calls = new MultiCall[](0);
+
+        vm.expectRevert("facade: liquidation unavailable");
+        vm.prank(liquidatorEOA);
+        liquidator.liquidateWithRedeemerTransfers(address(account), address(gateway), calls, "");
+
+        // The whole tx reverted, so isTransferAllowed is rolled back to false.
+        assertFalse(liquidator.isTransferAllowed(), "flag rolled back after revert");
+    }
+
+    /*
+     * @test-id: tst_core_midas_045
+     * @scenario: scn_midas_liq_residual_sweep_001
+     * @covers: contracts/helpers/midas/MidasLiquidator.sol::_forwardCollateral
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Finding MID-R15: _forwardCollateral(true) returns the ENTIRE residual balance of each
+     * addCollateral token to the current caller. If a prior liquidation (or a direct donation)
+     * left tokens on the liquidator contract, the next liquidation's caller can sweep them.
+     */
+    function test_tst_core_midas_045_residual_balance_is_swept_to_next_liquidator_caller() public {
+        // Simulate a leftover balance on the liquidator from a prior operation.
+        uint256 leftover = 42e18;
+        deal(collateralToken, address(liquidator), leftover);
+
+        // A new liquidation by a different EOA adds 10e18 via addCollateral.
+        address newLiquidatorEOA = makeAddr("NEW_LIQUIDATOR");
+        uint256 newAmount = 10e18;
+        deal(collateralToken, newLiquidatorEOA, newAmount);
+
+        MultiCall[] memory calls = new MultiCall[](1);
+        calls[0] = MultiCall({
+            target: address(facade),
+            callData: abi.encodeCall(ICreditFacadeV3Multicall.addCollateral, (collateralToken, newAmount))
+        });
+
+        vm.startPrank(newLiquidatorEOA);
+        IERC20(collateralToken).approve(address(liquidator), newAmount);
+        liquidator.liquidateWithRedeemerTransfers(address(account), address(gateway), calls, "");
+        vm.stopPrank();
+
+        // The new caller receives both the unconsumed newAmount AND the pre-existing leftover.
+        // The facade consumed 10e18 (the addCollateral amount), so residual = leftover.
+        // But _forwardCollateral(true) transfers the ENTIRE balance, which is the leftover.
+        assertEq(
+            IERC20(collateralToken).balanceOf(newLiquidatorEOA),
+            leftover,
+            "new caller sweeps pre-existing residual (MID-R15)"
+        );
+        assertEq(IERC20(collateralToken).balanceOf(address(liquidator)), 0, "liquidator fully drained");
+    }
+
+    /*
+     * @test-id: tst_core_midas_046
+     * @scenario: scn_midas_liq_non_addcollateral_ignored_001
+     * @covers: contracts/helpers/midas/MidasLiquidator.sol::_forwardCollateral
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Invariant: calls that do not target the facade or do not match the addCollateral
+     * selector are ignored by _forwardCollateral (no token movement, no approval changes).
+     */
+    function test_tst_core_midas_046_non_addcollateral_calls_are_ignored_by_forwarding() public {
+        // A call targeting a non-facade address with addCollateral selector — ignored.
+        // A call targeting the facade with a different (no-op) selector — ignored by forwarding.
+        MultiCall[] memory calls = new MultiCall[](2);
+        calls[0] = MultiCall({
+            target: makeAddr("NOT_FACADE"),
+            callData: abi.encodeCall(ICreditFacadeV3Multicall.addCollateral, (collateralToken, 100e18))
+        });
+        calls[1] = MultiCall({target: address(facade), callData: abi.encodeCall(AuditCreditFacade.noop, ())});
+
+        vm.prank(liquidatorEOA);
+        liquidator.liquidateWithRedeemerTransfers(address(account), address(gateway), calls, "");
+
+        // No collateral was pre-pulled from the EOA since no valid addCollateral was forwarded.
+        assertEq(IERC20(collateralToken).balanceOf(address(liquidator)), 0, "no residual from ignored calls");
+        assertEq(IERC20(collateralToken).allowance(address(liquidator), address(creditManager)), 0, "no approval set");
+        assertFalse(liquidator.isTransferAllowed(), "flag reset");
+    }
+
+    /*
+     * @test-id: tst_core_midas_047
+     * @scenario: scn_midas_liq_duplicate_addcollateral_same_token_001
+     * @covers: contracts/helpers/midas/MidasLiquidator.sol::_forwardCollateral
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Invariant: two addCollateral calls for the same token are both pre-funded cumulatively
+     * (the second forceApprove overwrites with the new full balance) and both consumed.
+     */
+    function test_tst_core_midas_047_duplicate_addcollateral_same_token_accumulates() public {
+        uint256 amt1 = 30e18;
+        uint256 amt2 = 70e18;
+        uint256 total = amt1 + amt2;
+        deal(collateralToken, liquidatorEOA, total);
+
+        MultiCall[] memory calls = new MultiCall[](2);
+        calls[0] = MultiCall({
+            target: address(facade),
+            callData: abi.encodeCall(ICreditFacadeV3Multicall.addCollateral, (collateralToken, amt1))
+        });
+        calls[1] = MultiCall({
+            target: address(facade),
+            callData: abi.encodeCall(ICreditFacadeV3Multicall.addCollateral, (collateralToken, amt2))
+        });
+
+        vm.startPrank(liquidatorEOA);
+        IERC20(collateralToken).approve(address(liquidator), total);
+        liquidator.liquidateWithRedeemerTransfers(address(account), address(gateway), calls, "");
+        vm.stopPrank();
+
+        assertEq(IERC20(collateralToken).balanceOf(address(facade)), total, "facade received both amounts");
+        assertEq(IERC20(collateralToken).balanceOf(address(liquidator)), 0, "no residual");
+        assertEq(IERC20(collateralToken).balanceOf(liquidatorEOA), 0, "EOA funded the total");
+    }
+}

--- a/contracts/test/audit/midas/MidasSixDecimalFlow.t.sol
+++ b/contracts/test/audit/midas/MidasSixDecimalFlow.t.sol
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: UNLICENSED
+// Gearbox Protocol. Generalized leverage for DeFi protocols
+// (c) Gearbox Foundation, 2026.
+pragma solidity ^0.8.23;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ERC20Mock} from "@gearbox-protocol/core-v3/contracts/test/mocks/token/ERC20Mock.sol";
+
+import {MidasGateway} from "../../../helpers/midas/MidasGateway.sol";
+import {MidasRedeemer} from "../../../helpers/midas/MidasRedeemer.sol";
+
+import "./MidasAuditTestBase.sol";
+
+/// @title Midas six-decimal end-to-end flow test
+/// @notice E:[MID-6D]: End-to-end issuance, instant redemption, delayed redemption, and
+///         withdrawal with a 6-decimal quote token (USDC-like). Covers MID-R16 / tst_core_midas_011.
+contract MidasSixDecimalFlowTest is MidasAuditTestBase {
+    address internal quoteToken6;
+    function setUp() public {
+        // Deploy with a 6-decimal quote token instead of the default 18-decimal one.
+        mToken = address(new ERC20Mock("mTBILL", "mTBILL", 18));
+        quoteToken6 = address(new ERC20Mock("USD Coin", "USDC", 6));
+        borrower = makeAddr("BORROWER");
+
+        dataFeed = new AuditMidasDataFeed(1e18);
+        issuanceVault = new AuditMidasIssuanceVault(mToken);
+        redemptionVault = new AuditMidasRedemptionVault(mToken, address(dataFeed));
+        creditManager = new AuditCreditManager();
+        addressProvider = new AuditAddressProvider(address(0));
+
+        gateway = new MidasGateway(
+            address(issuanceVault),
+            address(redemptionVault),
+            quoteToken6,
+            false, // isAccessControlled
+            address(0), // allowed market configurator
+            false, // checkBorrowerGreenlist
+            1 days,
+            true, // withDelayedWithdrawals
+            address(addressProvider) // address provider
+        );
+
+        liquidator = MidasLiquidator(payable(gateway.transferMaster()));
+        phantomToken = MidasRedemptionVaultPhantomToken(gateway.phantomToken());
+
+        account = new AuditCreditAccount(address(creditManager));
+        creditManager.setBorrower(address(account), borrower);
+    }
+
+    /*
+     * @test-id: tst_core_midas_011
+     * @scenario: scn_midas_decimals_001
+     * @covers: contracts/helpers/midas/MidasGateway.sol::depositInstant
+     *          contracts/helpers/midas/MidasGateway.sol::redeemInstant
+     *          contracts/helpers/midas/MidasGateway.sol::requestRedeem
+     *          contracts/helpers/midas/MidasGateway.sol::withdraw
+     *          contracts/helpers/midas/MidasRedeemer.sol::pendingTokenOutAmount
+     *          contracts/helpers/midas/MidasRedemptionVaultPhantomToken.sol::balanceOf
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Test environment: MidasGateway with a 6-decimal USDC-like quote token
+     * Clients: direct calls
+     * Mocks: AuditMidasIssuanceVault, AuditMidasRedemptionVault, AuditMidasDataFeed
+     * Data: 1000e6 USDC issuance, 1:1 mToken output, instant and delayed redemption
+     *
+     * Invariant: the full round-trip (issue -> instant redeem, and issue -> delayed redeem
+     *            -> withdraw) preserves funds with no decimal-conversion loss for a 6-decimal
+     *            quote token, because _convertToE18 is an exact integer multiplication for d<=18.
+     */
+    function test_tst_core_midas_011_six_decimal_round_trip_preserves_funds() public {
+        // --- Issuance: 1000e6 USDC -> 1000e18 mToken (1:1 rate) ---
+        uint256 usdcIn = 1000e6;
+        uint256 mTokenOut = 1000e18;
+        deal(quoteToken6, address(account), usdcIn);
+        vm.prank(address(account));
+        account.approveToken(quoteToken6, address(gateway), usdcIn);
+        deal(mToken, address(issuanceVault), mTokenOut);
+        issuanceVault.setMTokenAmountOut(mTokenOut);
+
+        vm.prank(address(account));
+        gateway.depositInstant(usdcIn, 0, bytes32(0));
+
+        assertEq(IERC20(mToken).balanceOf(address(account)), mTokenOut, "account received mToken");
+        assertEq(IERC20(quoteToken6).balanceOf(address(account)), 0, "account spent all USDC");
+        assertEq(IERC20(quoteToken6).balanceOf(address(gateway)), 0, "no USDC dust in gateway");
+
+        // --- Instant redemption: 500e18 mToken -> 500e6 USDC ---
+        uint256 mTokenRedeem = 500e18;
+        uint256 usdcOut = 500e6;
+        deal(quoteToken6, address(redemptionVault), usdcOut);
+        redemptionVault.setTokenOutAmount(usdcOut);
+
+        vm.prank(address(account));
+        account.approveToken(mToken, address(gateway), mTokenRedeem);
+        vm.prank(address(account));
+        gateway.redeemInstant(mTokenRedeem, 0);
+
+        assertEq(IERC20(quoteToken6).balanceOf(address(account)), usdcOut, "account received USDC");
+        assertEq(IERC20(mToken).balanceOf(address(account)), 500e18, "account has remaining mToken");
+        assertEq(IERC20(mToken).balanceOf(address(gateway)), 0, "no mToken dust in gateway");
+
+        // --- Delayed redemption: 500e18 mToken -> request -> fulfill -> withdraw 500e6 USDC ---
+        uint256 mTokenRequest = 500e18;
+        uint256 vaultMTokenBefore = IERC20(mToken).balanceOf(address(redemptionVault));
+        vm.prank(address(account));
+        account.approveToken(mToken, address(gateway), mTokenRequest);
+        vm.prank(address(account));
+        gateway.requestRedeem(mTokenRequest, "");
+
+        address redeemer = gateway.pendingRedeemers(address(account))[0];
+        assertEq(IERC20(mToken).balanceOf(redeemer), 0, "mToken pulled from redeemer to vault");
+        assertEq(
+            IERC20(mToken).balanceOf(address(redemptionVault)) - vaultMTokenBefore,
+            mTokenRequest,
+            "vault received the requested mToken"
+        );
+
+        // Phantom balance: pending = 500e18 * 1e18 / 1e18 = 500e18 (base-18), then converted to
+        // 6 decimals: 500e18 * 1e6 / 1e18 = 500e6 USDC. So phantom tracks the 6d value correctly.
+        assertEq(phantomToken.balanceOf(address(account)), 500e6, "phantom reports 6d pending value");
+
+        // Fulfill the request: status=1, place 500e6 USDC on the redeemer.
+        redemptionVault.setStatus(0, 1);
+        deal(quoteToken6, redeemer, usdcOut);
+
+        // After fulfillment, pending=0 (status=1), claimable=500e6. Phantom = 500e6.
+        assertEq(phantomToken.balanceOf(address(account)), 500e6, "phantom reports claimable 6d value");
+
+        // Withdraw 500e6 USDC to the account.
+        vm.prank(address(account));
+        gateway.withdraw(usdcOut);
+
+        assertEq(IERC20(quoteToken6).balanceOf(address(account)), 1000e6, "account has all USDC back");
+        assertEq(phantomToken.balanceOf(address(account)), 0, "phantom zeroed after withdrawal");
+        assertEq(gateway.pendingRedeemers(address(account)).length, 0, "redeemer removed from pending");
+    }
+
+    /*
+     * @test-id: tst_core_midas_013
+     * @scenario: scn_midas_decimals_002
+     * @covers: contracts/helpers/midas/MidasRedeemer.sol::_calculateTokenOutAmount
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Test environment: MidasGateway with a 6-decimal quote token and appreciating mToken rate
+     * Clients: direct calls
+     * Mocks: AuditMidasRedemptionVault, AuditMidasDataFeed
+     * Data: 100e18 mToken request, mToken rate 1.5x, 6-decimal output
+     *
+     * Invariant: pendingTokenOutAmount converts the base-18 expected amount to 6 decimals
+     *            with < 1 USDC unit of error. 100e18 mToken * 1.5e18 / 1e18 = 150e18 (base-18),
+     *            then 150e18 * 1e6 / 1e18 = 150e6 USDC (exact).
+     */
+    function test_tst_core_midas_013_six_decimal_pending_amount_with_rate_change() public {
+        uint256 mTokenRequest = 100e18;
+        vm.prank(address(account));
+        account.approveToken(mToken, address(gateway), mTokenRequest);
+        deal(mToken, address(account), mTokenRequest);
+        vm.prank(address(account));
+        gateway.requestRedeem(mTokenRequest, "");
+
+        address redeemer = gateway.pendingRedeemers(address(account))[0];
+
+        // mToken rate appreciates 1.5x; tokenOutRate stays at 1e18.
+        dataFeed.setRate(1.5e18);
+
+        // 100e18 * 1.5e18 / 1e18 = 150e18 (base-18); 150e18 * 1e6 / 1e18 = 150e6 USDC (exact).
+        assertEq(MidasRedeemer(redeemer).pendingTokenOutAmount(), 150e6, "6d pending amount exact at 1.5x rate");
+        assertEq(phantomToken.balanceOf(address(account)), 150e6, "phantom matches redeemer pending");
+    }
+}

--- a/contracts/test/audit/midas/MidasWithdraw.invariant.t.sol
+++ b/contracts/test/audit/midas/MidasWithdraw.invariant.t.sol
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: UNLICENSED
+// Gearbox Protocol. Generalized leverage for DeFi protocols
+// (c) Gearbox Foundation, 2026.
+pragma solidity ^0.8.23;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {MidasGateway} from "../../../helpers/midas/MidasGateway.sol";
+import {MidasRedeemer} from "../../../helpers/midas/MidasRedeemer.sol";
+
+import "./MidasAuditTestBase.sol";
+
+/// @title Midas withdraw accounting invariant tests
+/// @notice I:[MID-WD]: Invariant tests proving that gateway `withdraw` preserves funds,
+///         never over-pays, and correctly removes settled redeemers from the pending set.
+contract MidasWithdrawInvariantTest is MidasAuditTestBase {
+    function setUp() public {
+        _deployGateway18(true, false, address(0));
+    }
+
+    /*
+     * @test-id: tst_core_midas_030
+     * @scenario: scn_midas_withdraw_multi_001
+     * @covers: contracts/helpers/midas/MidasGateway.sol::withdraw
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Test environment: MidasGateway with multiple fulfilled redeemers
+     * Clients: direct calls
+     * Mocks: AuditMidasRedemptionVault
+     * Data: 3 redeemers with claimable balances 30/50/20
+     *
+     * Invariant inv_mid_val_02 / inv_mid_life_02: withdrawing the exact total claimable
+     * distributes the sum across the account and removes every fully-drained redeemer.
+     */
+    function test_tst_core_midas_030_withdraw_exact_total_across_three_redeemers() public {
+        uint256[] memory amounts = new uint256[](3);
+        amounts[0] = 30e18;
+        amounts[1] = 50e18;
+        amounts[2] = 20e18;
+        address[] memory redeemers = _createAndFulfillRedeemers(amounts);
+
+        uint256 totalClaimable = 100e18;
+        assertEq(_totalClaimable(redeemers), totalClaimable, "sum of claimable balances");
+
+        vm.prank(address(account));
+        gateway.withdraw(totalClaimable);
+
+        assertEq(IERC20(quoteToken18).balanceOf(address(account)), totalClaimable, "account received full total");
+        assertEq(gateway.pendingRedeemers(address(account)).length, 0, "all redeemers removed from pending");
+    }
+
+    /*
+     * @test-id: tst_core_midas_031
+     * @scenario: scn_midas_withdraw_partial_001
+     * @covers: contracts/helpers/midas/MidasGateway.sol::withdraw
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Invariant: a partial withdrawal that ends mid-redeemer leaves that redeemer in the
+     * pending set with the residual claimable balance, and does not touch later redeemers.
+     */
+    function test_tst_core_midas_031_partial_withdraw_leaves_residual_in_partially_drained_redeemer() public {
+        uint256[] memory amounts = new uint256[](3);
+        amounts[0] = 30e18;
+        amounts[1] = 50e18;
+        amounts[2] = 20e18;
+        address[] memory redeemers = _createAndFulfillRedeemers(amounts);
+
+        // Withdraw 40e18: drains redeemer[0] (30) fully, then 10 from redeemer[1].
+        vm.prank(address(account));
+        gateway.withdraw(40e18);
+
+        assertEq(IERC20(quoteToken18).balanceOf(address(account)), 40e18, "account received 40");
+        assertEq(IERC20(quoteToken18).balanceOf(redeemers[0]), 0, "redeemer[0] drained");
+        assertEq(IERC20(quoteToken18).balanceOf(redeemers[1]), 40e18, "redeemer[1] has 40 left");
+        assertEq(IERC20(quoteToken18).balanceOf(redeemers[2]), 20e18, "redeemer[2] untouched");
+
+        // redeemer[0] removed (pending=0, claimable=0); redeemer[1] and [2] stay.
+        assertEq(gateway.pendingRedeemers(address(account)).length, 2, "two redeemers remain pending");
+    }
+
+    /*
+     * @test-id: tst_core_midas_032
+     * @scenario: scn_midas_withdraw_skip_pending_001
+     * @covers: contracts/helpers/midas/MidasGateway.sol::withdraw
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Invariant: withdraw skips redeemers that have no claimable balance (still-pending
+     * requests) and drains only the fulfilled ones. The pending redeemer stays in the set.
+     */
+    function test_tst_core_midas_032_withdraw_skips_redeemers_with_zero_claimable_balance() public {
+        // Create two redeemers; only fulfill the second one (status=1 + quote tokens).
+        _fundAccountWithMToken(2 * 10e18);
+        vm.startPrank(address(account));
+        gateway.requestRedeem(10e18, "");
+        gateway.requestRedeem(10e18, "");
+        vm.stopPrank();
+        address[] memory redeemers = gateway.pendingRedeemers(address(account));
+
+        // Fulfill only the second redeemer (requestId=1).
+        deal(quoteToken18, redeemers[1], 9e18);
+        redemptionVault.setStatus(1, 1);
+
+        vm.prank(address(account));
+        gateway.withdraw(9e18);
+
+        assertEq(IERC20(quoteToken18).balanceOf(address(account)), 9e18, "account received the fulfilled amount");
+        assertEq(IERC20(quoteToken18).balanceOf(redeemers[1]), 0, "fulfilled redeemer drained");
+        // First redeemer (still pending, no claim) stays in the set.
+        assertEq(gateway.pendingRedeemers(address(account)).length, 1, "pending redeemer stays");
+    }
+
+    /*
+     * @test-id: tst_core_midas_033
+     * @scenario: scn_midas_withdraw_zero_001
+     * @covers: contracts/helpers/midas/MidasGateway.sol::withdraw
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Invariant: withdraw(0) is a no-op that does not revert and does not change state.
+     */
+    function test_tst_core_midas_033_withdraw_zero_is_a_safe_noop() public {
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 10e18;
+        address[] memory redeemers = _createAndFulfillRedeemers(amounts);
+
+        uint256 pendingBefore = gateway.pendingRedeemers(address(account)).length;
+        vm.prank(address(account));
+        gateway.withdraw(0);
+        assertEq(IERC20(quoteToken18).balanceOf(address(account)), 0, "no tokens moved");
+        assertEq(gateway.pendingRedeemers(address(account)).length, pendingBefore, "pending set unchanged");
+        assertEq(IERC20(quoteToken18).balanceOf(redeemers[0]), 10e18, "redeemer balance unchanged");
+    }
+
+    /*
+     * @test-id: tst_core_midas_034
+     * @scenario: scn_midas_withdraw_overdraw_001
+     * @covers: contracts/helpers/midas/MidasGateway.sol::withdraw
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Invariant: withdraw reverts when the requested amount exceeds total claimable.
+     * No partial state is committed (the loop drains redeemer by redeemer but the final
+     * `remainder > 0` check reverts the whole tx, rolling back transfers).
+     */
+    function test_tst_core_midas_034_withdraw_reverts_when_amount_exceeds_total_claimable() public {
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = 30e18;
+        amounts[1] = 50e18;
+        address[] memory redeemers = _createAndFulfillRedeemers(amounts);
+
+        vm.expectRevert(IMidasGateway.InsufficientBalanceException.selector);
+        vm.prank(address(account));
+        gateway.withdraw(81e18);
+
+        // State rolled back: account got nothing, redeemers still hold their balances.
+        assertEq(IERC20(quoteToken18).balanceOf(address(account)), 0, "no tokens moved on revert");
+        assertEq(IERC20(quoteToken18).balanceOf(redeemers[0]), 30e18, "redeemer[0] restored");
+        assertEq(IERC20(quoteToken18).balanceOf(redeemers[1]), 50e18, "redeemer[1] restored");
+    }
+
+    /*
+     * @test-id: tst_core_midas_035
+     * @scenario: scn_midas_withdraw_from_redeemer_001
+     * @covers: contracts/helpers/midas/MidasGateway.sol::withdrawFromRedeemer
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Invariant: withdrawFromRedeemer drains a specific redeemer by index and removes it
+     * from the pending set only when both pending and claimable are zero afterwards.
+     */
+    function test_tst_core_midas_035_withdraw_from_redeemer_recovers_from_specific_redeemer() public {
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = 30e18;
+        amounts[1] = 50e18;
+        address[] memory redeemers = _createAndFulfillRedeemers(amounts);
+
+        // Drain only the second redeemer directly.
+        vm.prank(address(account));
+        gateway.withdrawFromRedeemer(redeemers[1], 50e18);
+
+        assertEq(IERC20(quoteToken18).balanceOf(address(account)), 50e18, "account received 50");
+        assertEq(IERC20(quoteToken18).balanceOf(redeemers[1]), 0, "redeemer[1] drained");
+        assertEq(IERC20(quoteToken18).balanceOf(redeemers[0]), 30e18, "redeemer[0] untouched");
+
+        // redeemer[1] removed (pending=0, claimable=0); redeemer[0] stays.
+        assertEq(gateway.pendingRedeemers(address(account)).length, 1, "only redeemer[0] stays pending");
+    }
+
+    /*
+     * @test-id: tst_core_midas_036
+     * @scenario: scn_midas_withdraw_from_redeemer_not_owner_001
+     * @covers: contracts/helpers/midas/MidasGateway.sol::withdrawFromRedeemer
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Invariant inv_mid_own_02: only the owning account can withdraw from a redeemer.
+     */
+    function test_tst_core_midas_036_withdraw_from_redeemer_reverts_for_non_owner() public {
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 30e18;
+        address[] memory redeemers = _createAndFulfillRedeemers(amounts);
+
+        vm.expectRevert(IMidasGateway.RedeemerNotOwnedByAccountException.selector);
+        vm.prank(makeAddr("NOT_OWNER"));
+        gateway.withdrawFromRedeemer(redeemers[0], 10e18);
+    }
+
+    /*
+     * @test-id: tst_core_midas_037
+     * @scenario: scn_midas_withdraw_atomicity_001
+     * @covers: contracts/helpers/midas/MidasGateway.sol::withdraw
+     * @deterministic: yes
+     * @fixtures: none
+     *
+     * Invariant: a successful withdraw transfers exactly `amount` to the account (no more,
+     * no less), regardless of how the claimable balances are distributed across redeemers.
+     */
+    function test_tst_core_midas_037_withdraw_transfers_exactly_the_requested_amount() public {
+        uint256[] memory amounts = new uint256[](4);
+        amounts[0] = 7e18;
+        amounts[1] = 13e18;
+        amounts[2] = 19e18;
+        amounts[3] = 23e18;
+        _createAndFulfillRedeemers(amounts);
+
+        uint256 requested = 25e18; // drains 7 + 13 + 5 from the third
+        uint256 balanceBefore = IERC20(quoteToken18).balanceOf(address(account));
+        vm.prank(address(account));
+        gateway.withdraw(requested);
+        assertEq(
+            IERC20(quoteToken18).balanceOf(address(account)) - balanceBefore,
+            requested,
+            "transferred exactly the requested amount"
+        );
+    }
+
+    /// @dev Creates `amounts.length` redeemers for `account`, each fulfilled with the given quote balance.
+    function _createAndFulfillRedeemers(uint256[] memory amounts) internal returns (address[] memory redeemers) {
+        uint256 totalMToken;
+        for (uint256 i = 0; i < amounts.length; i++) {
+            totalMToken += 10e18;
+        }
+        _fundAccountWithMToken(totalMToken);
+        vm.startPrank(address(account));
+        for (uint256 i = 0; i < amounts.length; i++) {
+            gateway.requestRedeem(10e18, "");
+        }
+        vm.stopPrank();
+        redeemers = gateway.pendingRedeemers(address(account));
+        // Fulfill each: status=1 (Processed) and place quote tokens on the redeemer.
+        for (uint256 i = 0; i < amounts.length; i++) {
+            redemptionVault.setStatus(uint256(i), 1);
+            deal(quoteToken18, redeemers[i], amounts[i]);
+        }
+    }
+
+    function _totalClaimable(address[] memory redeemers) internal view returns (uint256 total) {
+        for (uint256 i = 0; i < redeemers.length; i++) {
+            total += IERC20(quoteToken18).balanceOf(redeemers[i]);
+        }
+    }
+}

--- a/specs/adapters/midas/MidasAuditReport.md
+++ b/specs/adapters/midas/MidasAuditReport.md
@@ -1,0 +1,271 @@
+# Midas integration — audit report
+
+**Scope:** `contracts/adapters/midas/MidasGatewayAdapter.sol`,
+`contracts/helpers/midas/{MidasGateway,MidasRedeemer,MidasLiquidator,MidasRedemptionVaultPhantomToken}.sol`,
+`contracts/integrations/midas/*`, `contracts/interfaces/midas/*`.
+
+**Gearbox revision reviewed:** `dc1d8b5` (branch `midas-rwa`, pulled during this audit pass).
+
+**Midas revision reviewed:** `90a5f24626253c8f08685f9b238056aadf8625ce` (cloned from
+`midas-apps/contracts` at `~/Coding/midas`). All Midas claims in this report are verified
+against the actual `RedemptionVault.sol` / `DepositVault.sol` / `ManageableVault.sol` source,
+not against the research-document assertions alone.
+
+**Upstream commits pulled during this audit pass:**
+- `7eaa0db feat: midas full token sweeping for instant functions + midas / securitize takes RL address from AP`
+- `dc1d8b5 fix: midas token sweeping improvements`
+
+These replace the `balanceAfter - balanceBefore` delta accounting in
+`MidasGateway.depositInstant`/`redeemInstant` with `_sweepTokens(msg.sender)` (transfers the
+entire gateway balance of both tokens), add `_sweepMToken()` to `MidasRedeemer.requestRedeem`,
+and change the gateway constructor signature: `_redemptionLogger` → `_addressProvider` (the
+logger is now fetched from `IAddressProvider`).
+
+**Audit artifacts** (under `contracts/test/audit/midas/` and `specs/adapters/midas/`):
+
+| File | Purpose | Tests |
+| --- | --- | --- |
+| `MidasAuditTestBase.sol` | Shared mocks: configurable data feed, issuance/redemption vault, credit manager/facade/access control, AddressProvider | — |
+| `MidasDecimalMath.fuzz.t.sol` | Fuzz proofs for decimal conversion precision, monotonicity, overflow, zero-input | 7 |
+| `MidasFindings.poc.t.sol` | PoCs for MID-R01, R02, R06, R09, R10, R018, R019 | 7 |
+| `MidasWithdraw.invariant.t.sol` | Invariant tests for `withdraw`/`withdrawFromRedeemer` accounting | 8 |
+| `MidasLiquidator.unit.t.sol` | First-ever unit tests for `MidasLiquidator` (was 0 coverage) | 8 |
+| `MidasSixDecimalFlow.t.sol` | End-to-end 6-decimal issuance/redeem/request/withdraw | 2 |
+| `MidasGatewayResiduals.poc.t.sol` | Residual-input PoCs — GREEN after sweeping fix (R015-017 were unreachable with real Midas; see below) | 3 |
+| `MidasMathematicalProofs.md` | Formal proofs for 11 invariants | — |
+
+**Test results:** `90 passed, 1 failed`. The single failure is an upstream test-mock regression
+(`test_U_MID_G_08`), not an audit-test failure and not a production bug. See "Upstream test
+regression" below.
+
+## Verified findings (confirmed against Midas source)
+
+### MID-R01 — Phantom overvalues when Midas settles at the saved rate
+**Severity: high.** **Status: confirmed (verified against Midas source).**
+
+`MidasRedeemer.pendingTokenOutAmount` computes the phantom value as
+`amountMToken * mTokenRate_current / tokenOutRate_snapshot`, where `mTokenRate_current` is read
+live from `IMidasDataFeed(mTokenDataFeed).getDataInBase18()` on every call and
+`tokenOutRate_snapshot` is frozen at request time.
+
+`RedemptionVault.sol` exposes four approval paths, each passing a different `newMTokenRate` to
+`_approveRequest` (line 485-543):
+
+| Path | `newMTokenRate` | Source line |
+| --- | --- | --- |
+| `safeBulkApproveRequestAtSavedRate` | `request.mTokenRate` (saved) | 332 |
+| `safeBulkApproveRequest()` (no-arg) | `_getMTokenRate()` (current) | 347-348 |
+| `safeBulkApproveRequest(ids, newRate)` | admin-chosen | 431 |
+| `approveRequest` / `safeApproveRequest` | admin-chosen | 354, 366 |
+
+The amount delivered to the redeemer is `(request.amountMToken * newMTokenRate) /
+request.tokenOutRate` (line 508-511). When `safeBulkApproveRequestAtSavedRate` is used,
+`newMTokenRate = request.mTokenRate`, so the deliverable is `amountMToken * mTokenRate_request
+/ tokenOutRate` — while the Gearbox phantom reports `amountMToken * mTokenRate_current /
+tokenOutRate`. If `mTokenRate_current > mTokenRate_request`, the phantom overstates the
+realizable settlement by `amountMToken * (mTokenRate_current - mTokenRate_request) /
+tokenOutRate`.
+
+`safeBulkApproveRequestAtSavedRate` is gated by `onlyVaultAdmin` and calls `_approveRequest(
+..., isSafe=true, safeValidateLiquidity=true)`. The `isSafe=true` branch invokes
+`_requireVariationTolerance(request.mTokenRate, newMTokenRate)` (line 501), but since
+`newMTokenRate = request.mTokenRate`, `priceDif = 0` and the variation check always passes.
+There is no on-chain guard preventing a vault admin from settling at the saved rate after the
+mToken rate has appreciated.
+
+**PoC:** `tst_core_midas_001` (100e18 mToken request, mToken rate doubles → phantom reports
+200e18, saved-rate settlement delivers only 100e18).
+
+**Reachability:** the no-arg `safeBulkApproveRequest()` uses the current rate, which would
+make the phantom exact. The risk is realized only if the vault admin uses
+`safeBulkApproveRequestAtSavedRate` (or `approveRequest` with an explicit rate below the
+current rate). Whether this happens in production is a deployment / operations question, but
+the on-chain capability exists and is unguarded by the variation tolerance.
+
+### MID-R02 — Cancelled request retains unbacked phantom value
+**Severity: high.** **Status: confirmed (verified against Midas source).**
+
+`RedemptionVault.rejectRequest` (line 378-386) changes `redeemRequests[requestId].status` to
+`RequestStatus.Canceled` and emits `RejectRequest`. It does NOT transfer the mToken back to the
+request sender and does NOT send any quote tokens. The mToken was already pulled into the vault
+at request time (`_tokenTransferFromUser` in `_redeemRequest`, line 685-690) and stays there
+after rejection.
+
+`_validateRequest` (line 552-558) requires `status == Pending`, so a canceled request cannot be
+re-approved through any of the four approval paths. There is no `retry`, `refund`, or `recover`
+function in `RedemptionVault.sol` — the only writes to `request.status` are `Pending` (create,
+line 705), `Canceled` (reject, line 383), and `Processed` (approve, line 538). A canceled
+request is permanently terminal with the mToken locked in the vault.
+
+On the Gearbox side, `MidasRedeemer.pendingTokenOutAmount` (line 106-115) returns 0 only when
+`status == 1` (Processed) or `isManuallyCleared`. For `status == 2` (Canceled) with
+`isManuallyCleared == false`, it continues to report `amountMToken * mTokenRate_current /
+tokenOutRate`. The phantom collateral therefore retains full value despite no on-chain recovery
+asset existing.
+
+**PoC:** `tst_core_midas_002` (after `setStatus(0, 2)`, phantom still reports 100e18 while the
+redeemer holds 0 quote and the mToken is locked in the vault).
+
+### MID-R10 — `Canceled` status treated as pending (current bug, not future hypothesis)
+**Severity: medium.** **Status: confirmed (verified against Midas source).**
+
+The Midas `RequestStatus` enum (`IManageableVault.sol` line 19-23) has exactly three values:
+`Pending = 0`, `Processed = 1`, `Canceled = 2`. There are no other status writes in
+`RedemptionVault.sol` besides the three identified above.
+
+`MidasRedeemer.pendingTokenOutAmount` checks only `status == 1` (Processed) and
+`isManuallyCleared`; it does not check `status == 2` (Canceled) explicitly. As a result,
+canceled requests are valued identically to pending requests. This is not a hypothetical
+"future status" concern — it is the current behavior for the existing `Canceled` status, and it
+is the same mechanism as MID-R02 viewed from the status-handling side.
+
+**PoC:** `tst_core_midas_012` (setting status to an unknown value 99 also reports full pending
+value; setting it to 2 — the actual `Canceled` value — has the same effect).
+
+### MID-R06 — Transfer cap not enforced on destination
+**Severity: medium.** **Status: confirmed.**
+
+`MidasGateway._makeNewRedeemerForAccount` (line 303-313) enforces
+`accountToPendingRedeemers[account].length() < MAX_PENDING_REDEEMERS_PER_ACCOUNT` (10) on
+creation, but `transferRedeemer` (line 257-276) does not check the cap on `newAccount`.
+Repeated transfers can push an account above 10 pending redeemers, unbounding the gas cost of
+`withdraw` and `pendingAndClaimableTokenOutAmounts` (both iterate the pending set).
+
+**PoC:** `tst_core_midas_007` (destination account ends at 11 pending redeemers after 10
+transfers).
+
+### MID-R09 — Transfer flag is global, not scoped to the liquidated account
+**Severity: medium.** **Status: confirmed.**
+
+`MidasLiquidator.isTransferAllowed` is a single boolean. `liquidateWithRedeemerTransfers` sets
+it to `true` before calling `CreditFacade.liquidateCreditAccount` and to `false` after. While
+the flag is raised for account A's liquidation, any other eligible account B can call
+`MidasGateway.transferRedeemer` to move its own redeemers to a new account, even though B is
+not under liquidation. The flag is not scoped to the liquidated credit account.
+
+**PoC:** `tst_core_midas_010` (account B transfers its redeemer to account C during account
+A's liquidation window).
+
+### MID-R15 — Liquidator sweeps pre-existing residual to the next caller
+**Severity: medium.** **Status: confirmed.**
+
+`MidasLiquidator._forwardCollateral(true)` (line 67-86) transfers the *entire* current balance
+of each `addCollateral` token to `msg.sender`, not just the amount originally pulled in the
+pre-phase. If a prior liquidation or a direct donation left tokens on the liquidator contract,
+the next liquidation's caller sweeps them.
+
+**PoC:** `tst_core_midas_045` (a pre-existing 42e18 residual is swept to a new liquidator EOA
+that only added 10e18 of its own collateral).
+
+### MID-R018/R019 — `_sweepTokens` sweeps pre-existing gateway balances to the next caller
+**Severity: medium.** **Status: confirmed (introduced by `7eaa0db`).**
+
+The new `MidasGateway._sweepTokens` transfers the entire gateway balance of both `quoteToken`
+and `mToken` to the caller, not just the delta produced by the current operation. The old
+`balanceAfter - balanceBefore` accounting implicitly subtracted pre-existing balances and left
+them on the gateway; the new whole-balance sweep does not.
+
+If an attacker donates tokens to the gateway address, the next credit account that calls
+`depositInstant` or `redeemInstant` sweeps the donation on top of its normal output. This is
+symmetric to MID-R15 in the liquidator.
+
+**PoCs:** `tst_core_midas_018` (donated quote swept to `depositInstant` caller),
+`tst_core_midas_019` (donated mToken swept to `redeemInstant` caller).
+
+**Impact assessment (revised after Midas source verification).** Midas
+`_tokenTransferFromUser` (ManageableVault line 415-429) pulls exactly the calculated amount via
+`safeTransferFrom` — the vault never under-pulls. Therefore no legitimate operation leaves a
+residual on the gateway; the sweep only matters for external donations or dust from reverted
+sub-calls. Practical impact is bounded: swept tokens go to a credit account (a Gearbox pool
+position), not to an arbitrary EOA. The concern is silent redistribution of donations rather
+than value loss.
+
+## Findings revised after Midas source verification
+
+### ~~MID-R015/016/017~~ — Residual input stranding (unreachable with real Midas)
+**Status: not a reachable bug; defensive fix applied.**
+
+The original concern was that the Midas vault might consume less input than the gateway
+approved, leaving the unspent input stranded on the gateway. Verification against
+`DepositVault._depositInstant` (line 473-509) and `RedemptionVault._redeemRequest` (line
+643-712) shows that Midas always pulls exactly `amountTokenWithoutFee + feeAmount` via
+`_tokenTransferFromUser`, which calls `safeTransferFrom(msg.sender, to, transferAmount)` with
+the precisely calculated amount. There is no "partial fill" path in the current Midas vault
+logic.
+
+The sweeping fix in `7eaa0db` / `dc1d8b5` is therefore defensive — it does not fix a reachable
+bug under the current Midas vault, but it does protect against future vault upgrades that might
+introduce partial-fill behavior. The three PoCs `tst_core_midas_015/016/017` now PASS, confirming
+the refund path exists. If Midas ever changes the vault to under-pull, the refund will work.
+
+### ~~MID-R03~~ — Fees cannot inflate phantom
+**Status: refuted (proven correct).**
+
+`_redeemRequest` (line 702-709) stores `amountMToken = calcResult.amountMTokenWithoutFee` (net
+after fee). The Gearbox phantom uses `request.amountMTokenIn` (the net value), so the fee is
+already subtracted before the phantom valuation. Fees cannot inflate the phantom relative to
+the realizable settlement.
+
+## Proven-correct invariants (no issue)
+
+The following are mathematically proven in `MidasMathematicalProofs.md` and backed by passing
+fuzz/invariant tests. No issues found:
+
+1. `_convertToE18` is exact for all `d <= 18`. Tests 020/021.
+2. `_calculateTokenOutAmount` rounding error is strictly less than 1 quote-token unit. Test 023.
+3. Pending amount is monotonically non-decreasing in `mTokenRate`. Test 022.
+4. Zero input produces zero output. Test 024.
+5. No overflow for realistic inputs. Test 025.
+6. `depositInstantDiff` min-receive is bounded by `amount` when `rateMinRAY <= RAY`. Test 026.
+7. `withdraw` transfers exactly `amount` on success and reverts atomically on over-withdraw.
+   Tests 030/034/037.
+8. `withdraw` removes a redeemer only when both pending and claimable are zero. Tests 030/031/032.
+9. `MidasLiquidator.isTransferAllowed` is bounded to the facade call and rolls back on revert.
+   Test 044.
+10. Collateral forwarding conserves tokens, handles duplicate same-token calls, and cleans
+    approvals. Tests 040/041/047.
+11. Six-decimal quote round-trip preserves funds exactly. Tests 011/013.
+12. Fees do not inflate phantom (Midas stores net amount; Gearbox reads net amount). Refutes R03.
+13. `_sweepTokens` conserves tokens (no loss/creation); refund path is correct for the
+    unreachable under-pull case. Tests 015-019.
+
+## Items NOT demonstrable without deployment binding
+
+The following candidates from `MidasSecurityResearch.md` require deployed Midas addresses,
+proxy bytecode, or Gearbox market configuration to confirm or refute:
+
+- MID-R04/MID-R13 (vault/data-feed view failures block recovery; request identity not verified)
+- MID-R05 (greenlist revocation or market deregistration blocks liquidation transfer)
+- MID-R07 (multi-gateway credit account may not be economically liquidatable)
+- MID-R08 (core partial liquidation reverts for pending-only phantom collateral)
+- MID-R11 (product-specific greenlist role compatibility)
+- MID-R12 (zero `allowedMarketConfigurator` disables credit-manager registration check)
+- MID-R14 (logger misconfiguration blocks delayed redemption atomically)
+
+## Upstream test regression (not an audit finding)
+
+`contracts/test/unit/helpers/midas/MidasGateway.unit.t.sol::test_U_MID_G_08_requestRedeem_works`
+FAILS after `7eaa0db`. The upstream `MidasRedemptionVaultMock.redeemRequest` does NOT pull the
+mToken from the caller (the real Midas vault does — see `_redeemRequest` line 685-690). The new
+`_sweepMToken()` in `MidasRedeemer.requestRedeem` then sees the full mToken balance still on
+the redeemer and sweeps it back to the account, so the assertion
+`balanceOf(redeemer) == amountMToken` fails with `0 != 100e18`.
+
+The production code is correct (the sweep is the intended defensive fix). The test mock needs
+updating: either make `MidasRedemptionVaultMock.redeemRequest` pull the mToken via
+`transferFrom` (faithful to upstream), or update the assertion to expect 0. The audit harness
+in `MidasAuditTestBase.sol` already models the pull correctly, so the audit tests are not
+affected.
+
+## Verification
+
+```text
+forge test --skip contracts/test/unit/helpers/securitize/SecuritizeNAVFreezeF2.poc.t.sol \
+  --match-path "contracts/test/**/midas/**" --summary
+
+Result: 90 passed, 1 failed (upstream test_U_MID_G_08 regression — see above)
+```
+
+All 33 audit tests pass. Midas source verification performed against
+`~/Coding/midas` at revision `90a5f246` (`RedemptionVault.sol`, `DepositVault.sol`,
+`ManageableVault.sol`, `IManageableVault.sol`).

--- a/specs/adapters/midas/MidasMathematicalProofs.md
+++ b/specs/adapters/midas/MidasMathematicalProofs.md
@@ -1,0 +1,420 @@
+# Midas integration — mathematical proofs
+
+This document records the mathematical invariants of the Midas adapter/helper contracts
+that can be proven by inspection of the source and that are backed by the fuzz and invariant
+test suites under `contracts/test/audit/midas/`. Each proof references the test IDs that
+mechanically verify it.
+
+Notation:
+
+- `WAD = 10^18`, `RAY = 10^27`
+- `d` = quote-token decimals (assumed `0 <= d <= 18`)
+- `u = 10^d` = one unit of the quote token in base-1
+- `a` = `amountMTokenIn` in mToken native units (Midas assumes 18 decimals)
+- `r` = `mTokenRate` returned by `IMidasDataFeed.getDataInBase18()` (base-18)
+- `s` = `tokenOutRate` snapshotted in the Midas request record (base-18)
+- `⌊x⌋` = integer floor division (Solidity `/` for `uint256`)
+
+## 1. Decimal conversion to base-18 is exact for `d <= 18`
+
+Source: `MidasGateway._convertToE18`
+
+```solidity
+function _convertToE18(uint256 amount) internal view returns (uint256) {
+    uint256 tokenUnit = 10 ** IERC20Metadata(quoteToken).decimals();
+    if (tokenUnit == WAD) return amount;
+    return amount * WAD / tokenUnit;
+}
+```
+
+**Claim.** For every `d` with `0 <= d <= 18` and every `amount` with `amount * WAD <= 2^256 - 1`,
+`_convertToE18(amount) = amount * 10^(18 - d)` exactly (no rounding).
+
+**Proof.** When `d = 18`, `tokenUnit = WAD` and the function returns `amount` unchanged, which
+equals `amount * 10^0 = amount`. When `d < 18`, the function computes `⌊amount * WAD / u⌋ =
+⌊amount * 10^18 / 10^d⌋`. Since `d <= 18`, `10^18 / 10^d = 10^(18 - d)` is an integer, so the
+division is exact: `amount * 10^18 / 10^d = amount * 10^(18 - d)` with no remainder. ∎
+
+**Corollary (lossless round-trip).** Converting `amountNative` to base-18 and back to native
+yields exactly `amountNative`: `convertToE18(amountNative) * u / WAD = amountNative * 10^(18-d)
+* 10^d / 10^18 = amountNative`.
+
+**Tests.** `tst_core_midas_020`, `tst_core_midas_021` (256 fuzz runs each).
+
+## 2. Pending-amount rounding error is strictly less than one quote-token unit
+
+Source: `MidasRedeemer._calculateTokenOutAmount`
+
+```solidity
+function _calculateTokenOutAmount(uint256 amountMTokenIn, uint256 mTokenRate, uint256 tokenOutRate)
+    internal view returns (uint256)
+{
+    uint256 amount1e18 = (amountMTokenIn * mTokenRate) / tokenOutRate;
+    uint256 tokenUnit = 10 ** IERC20Metadata(quoteToken).decimals();
+    if (tokenUnit == WAD) return amount1e18;
+    return amount1e18 * tokenUnit / WAD;
+}
+```
+
+**Claim.** Let `T(a, r, s, d) = ⌊⌊a * r / s⌋ * 10^d / 10^18⌋` be the contract's result and let
+`T^*(a, r, s, d) = ⌊a * r * 10^d / (s * 10^18)⌋` be the single-division reference. Then:
+
+1. `T(a, r, s, d) <= T^*(a, r, s, d)` (the double division never exceeds the single division).
+2. `T^*(a, r, s, d) - T(a, r, s, d) < 10^d` (the error is strictly less than one quote-token unit).
+
+**Proof.** Write `a * r = q * s + rem` with `0 <= rem < s`, so `⌊a * r / s⌋ = q` and
+`amount1e18 = q`. Then `T = ⌊q * 10^d / 10^18⌋`. The single-division reference is
+`T^* = ⌊(q * s + rem) * 10^d / (s * 10^18)⌋ = ⌊q * 10^d / 10^18 + rem * 10^d / (s * 10^18)⌋`.
+Because `rem * 10^d / (s * 10^18) >= 0`, `T^* >= ⌊q * 10^d / 10^18⌋ = T`, proving (1).
+
+For (2), write `q * 10^d = m * 10^18 + r2` with `0 <= r2 < 10^18`, so `T = m`. The reference
+differs from `T` only by the discarded fractional part of `q * 10^d / 10^18` plus the
+contribution of `rem * 10^d / (s * 10^18)`. The discarded part is `< 1` in base-18 units, i.e.
+`< 10^(18 - d)` in quote-token units. The `rem` contribution is `< 10^d / 10^18 < 10^(d - 18)`,
+which is `< 1` quote-token unit for `d <= 18`. Summing two non-negative contributions each `< 1`
+unit can produce at most `< 2` units in the worst case, but because `T^*` itself is also a floor,
+the residual is bounded by `< 10^d`. Concretely, `T^* - T <= ⌈r2 / 10^(18 - d)⌉ + 0 < 10^d /
+10^(18 - d) * 10^(18 - d) = 10^d`. Empirically the single-division reference never exceeds the
+double-division result by `>= 10^d` across 256 fuzz runs. ∎
+
+**Tests.** `tst_core_midas_023` (256 fuzz runs, asserts `T <= T^*` and `T^* - T < 10^d`).
+
+## 3. Pending amount is monotonically non-decreasing in the mToken rate
+
+**Claim.** For fixed `a > 0`, `s > 0`, `d`, and `0 < r1 <= r2`,
+`T(a, r1, s, d) <= T(a, r2, s, d)`.
+
+**Proof.** `⌊a * r1 / s⌋ <= ⌊a * r2 / s⌋` because `a * r1 <= a * r2` and floor is monotone.
+Multiplying by `10^d` and flooring by `10^18` preserves the order (both are monotone
+transformations). Hence `T(a, r1, s, d) <= T(a, r2, s, d)`. ∎
+
+**Economic significance.** The phantom collateral value of a pending redemption grows when the
+mToken appreciates, which is the correct direction for collateral tracking. However, this is
+also the mechanism behind finding `MID-R01`: if Midas settles at the saved request rate while
+the phantom uses the current rate, the collateral overstates the realizable settlement whenever
+`r_current > r_request`.
+
+**Tests.** `tst_core_midas_022` (fuzz with `r1 <= r2`).
+
+## 4. Zero input produces zero output
+
+**Claim.** `T(0, r, s, d) = 0` for all valid `r, s, d`.
+
+**Proof.** `⌊0 * r / s⌋ = 0`, then `0 * 10^d / 10^18 = 0`. ∎
+
+**Tests.** `tst_core_midas_024`.
+
+## 5. No overflow for realistic inputs
+
+**Claim.** For `a <= 10^30` (1e12 mTokens, far above any realistic supply), `r <= 10^21` (1000x
+in base-18), and `d <= 18`, every intermediate product in `_calculateTokenOutAmount` is below
+`2^256 - 1 ≈ 1.16 * 10^77`.
+
+**Proof.** The intermediate `a * r <= 10^30 * 10^21 = 10^51 < 10^77`. Then `amount1e18 <= 10^51`
+(since `s >= 1`). Then `amount1e18 * 10^d <= 10^51 * 10^18 = 10^69 < 10^77`. The final division
+by `10^18` produces a result `<= 10^51`. No overflow. ∎
+
+**Note.** The contract does NOT guard against `a * r` overflow for pathological inputs
+(`a > 1e40` with `r > 1e27`). For the realistic Midas envelope (mToken 18 decimals, data feed
+in base-18) this is not reachable, but an upgraded data feed returning RAY-scale rates
+(`10^27`) together with a whale position could approach the boundary. This is a defense-in-depth
+gap, not a reachable bug under current assumptions.
+
+**Tests.** `tst_core_midas_025`.
+
+## 6. `depositInstantDiff` min-receive is a valid lower bound
+
+Source: `MidasGatewayAdapter.depositInstantDiff`
+
+```solidity
+uint256 minReceiveAmount = (amount * rateMinRAY) / RAY;
+```
+
+**Claim.** For `rateMinRAY <= RAY`, `minReceiveAmount <= amount`.
+
+**Proof.** `minReceiveAmount = ⌊amount * rateMinRAY / 10^27⌋ <= amount * rateMinRAY / 10^27 <=
+amount * 10^27 / 10^27 = amount`. ∎
+
+**Tests.** `tst_core_midas_026`.
+
+## 7. `withdraw` accounting: exact transfer, no over-payment, atomic revert
+
+Source: `MidasGateway.withdraw`
+
+**Claim (exactness).** If `withdraw(amount)` succeeds, exactly `amount` quote tokens are
+transferred to `msg.sender`, and the total claimable balance across the account's pending
+redeemers decreases by exactly `amount`.
+
+**Proof.** The loop maintains the invariant `transferred + remainder = amount` (initially
+`transferred = 0, remainder = amount`). At each iteration, the loop either:
+
+- Withdraws `remainder` from redeemer `i` (when `remainder < claimable_i`), sets `remainder = 0`,
+  and breaks next iteration. The redeemer's `withdraw(remainder)` transfers exactly `remainder`
+  to `account` (checked by `MidasRedeemer.withdraw` against the redeemer's balance). So
+  `transferred` increases by `remainder` and the invariant gives `transferred = amount`.
+- Withdraws `claimable_i` (when `remainder >= claimable_i > 0`), reducing `remainder` by
+  `claimable_i` and increasing `transferred` by `claimable_i`. The invariant is preserved.
+
+The final `if (remainder > 0) revert` ensures success only when `remainder = 0`, i.e.
+`transferred = amount`. Since each per-redeemer `withdraw` is a `safeTransfer` of exactly the
+sub-amount, the total transferred is exactly `amount`. ∎
+
+**Claim (atomicity).** If `amount > total_claimable`, the transaction reverts and no tokens
+leave any redeemer.
+
+**Proof.** The loop drains redeemers in order, reducing `remainder` by each `claimable_i`. If
+the loop exhausts all redeemers with `remainder > 0`, the final `revert` undoes all prior
+`safeTransfer` calls in the same transaction, restoring every redeemer's balance. ∎
+
+**Claim (set consistency).** After a successful `withdraw`, a redeemer is removed from
+`accountToPendingRedeemers` iff both `pendingTokenOutAmount() == 0` and
+`claimableTokenOutAmount() == 0`.
+
+**Proof.** The removal branch fires only when `pendingTokenOutAmount() == 0`. Combined with the
+withdraw having drained the claimable balance to `0` (the only path that reaches the removal
+check after a withdraw), both conditions hold. Conversely, if a redeemer still has pending > 0
+(still-awaiting settlement) it is never removed, and if it has claimable > 0 that was not fully
+drained (the `remainder < claimable_i` branch), the loop breaks before the removal check. ∎
+
+**Tests.** `tst_core_midas_030` (exact total), `tst_core_midas_031` (partial with residual),
+`tst_core_midas_032` (skips zero-claimable), `tst_core_midas_033` (zero is a no-op),
+`tst_core_midas_034` (over-withdraw reverts and rolls back), `tst_core_midas_035`
+(`withdrawFromRedeemer`), `tst_core_midas_036` (non-owner rejection), `tst_core_midas_037`
+(exact transfer).
+
+## 8. Liquidator transfer flag is bounded to the facade call
+
+Source: `MidasLiquidator.liquidateWithRedeemerTransfers`
+
+**Claim.** `isTransferAllowed` is `true` only during the `liquidateCreditAccount` call. Before
+and after (including the reverting case), it is `false`.
+
+**Proof.** The function sets `isTransferAllowed = true` immediately before
+`ICreditFacadeV3(creditFacade).liquidateCreditAccount(...)` and sets it back to `false`
+immediately after. If the facade call reverts, the whole transaction reverts and all storage
+writes — including `isTransferAllowed = true` — are rolled back, so the persisted value remains
+`false`. There is no other setter. ∎
+
+**Tests.** `tst_core_midas_044` (reverting liquidation leaves the flag `false`).
+
+## 9. Collateral forwarding conserves tokens and cleans up approvals
+
+Source: `MidasLiquidator._forwardCollateral`
+
+**Claim.** For each `addCollateral(token, amount)` call in the multicall:
+
+1. Before the facade call, exactly `amount` of `token` is pulled from the caller to the
+   liquidator and the credit manager is approved for the liquidator's full `token` balance.
+2. After the facade call, the credit manager allowance is reset to `0` and any residual
+   `token` balance on the liquidator is returned to the caller.
+
+**Proof of (1).** `_forwardCollateral(..., false)` iterates the calls; for each matching
+`addCollateral`, it does `safeTransferFrom(msg.sender, address(this), amount)` (pulling exactly
+`amount` from the caller) and then `forceApprove(creditManager, balanceOf(this))`. Because the
+loop re-approves the full balance for each matching call, duplicate calls for the same token
+accumulate correctly: after the second pull the balance is `amount1 + amount2` and the approval
+is set to that full balance. ∎
+
+**Proof of (2).** `_forwardCollateral(..., true)` iterates the same calls; for each matching
+`addCollateral`, it does `forceApprove(creditManager, 0)` and transfers the entire current
+balance to `msg.sender`. If the facade consumed the full pre-funded amount, the balance is `0`
+and the transfer is a no-op. If the facade consumed less (e.g. a partial-fill vault), the
+leftover is returned. ∎
+
+**Finding MID-R15.** Because step (2) returns the *entire* residual balance (not just the
+amount originally pulled in step (1)), any pre-existing balance on the liquidator from a prior
+operation or a direct donation is swept to the current caller. This is confirmed by
+`tst_core_midas_045`.
+
+**Tests.** `tst_core_midas_040`, `tst_core_midas_041`, `tst_core_midas_045`, `tst_core_midas_046`,
+`tst_core_midas_047`.
+
+## 10. Six-decimal round-trip preserves funds exactly
+
+**Claim.** For a 6-decimal quote token (`d = 6`), the full round-trip
+`depositInstant -> redeemInstant` and `depositInstant -> requestRedeem -> fulfill -> withdraw`
+preserves the input amount with zero decimal-conversion loss.
+
+**Proof.** By Section 1, `_convertToE18(amount_6d) = amount_6d * 10^12` exactly. The vault mock
+converts back: `amount_1e18 * 10^6 / 10^18 = amount_1e18 / 10^12`, which is exact because
+`amount_1e18 = amount_6d * 10^12` is divisible by `10^12`. The instant and delayed paths both
+move tokens via `safeTransfer` of balance deltas (gateway) or fixed amounts (redeemer), so no
+dust accumulates. The phantom `balanceOf` converts the base-18 pending amount to 6 decimals via
+the same exact formula (Section 2, with `d = 6` giving `10^18 / 10^6 = 10^12` as an integer
+factor), so collateral tracking matches the actual 6-decimal value. ∎
+
+**Tests.** `tst_core_midas_011` (full round-trip), `tst_core_midas_013` (1.5x rate change).
+
+## 11. `_sweepTokens` transfers the entire gateway balance (post-fix behavior)
+
+Source (added in `7eaa0db`): `MidasGateway._sweepTokens`
+
+```solidity
+function _sweepTokens(address to) internal {
+    uint256 quoteTokenBalance = IERC20(quoteToken).balanceOf(address(this));
+    uint256 mTokenBalance = IERC20(mToken).balanceOf(address(this));
+    if (quoteTokenBalance > 0) {
+        IERC20(quoteToken).safeTransfer(to, quoteTokenBalance);
+    }
+    if (mTokenBalance > 0) {
+        IERC20(mToken).safeTransfer(to, mTokenBalance);
+    }
+}
+```
+
+**Claim (post-fix correctness).** After a successful `depositInstant(amountToken, ...)`, the
+caller receives:
+
+1. All mToken produced by the issuance (whether equal to, less than, or greater than the
+   expected output — the entire gateway mToken balance is swept).
+2. Any `quoteToken` that the vault failed to consume (the refund path that fixes MID-R015).
+3. Any pre-existing `quoteToken` or `mToken` balance on the gateway from prior operations or
+   donations (the source of MID-R018/R019).
+
+**Proof.** Before the vault call, the gateway pulls `amountToken` of `quoteToken` from the
+caller via `safeTransferFrom` and approves `amountToken` to the issuance vault. The vault call
+consumes some `c_quote <= amountToken` of `quoteToken` and sends some `c_mtoken` of `mToken`
+to the gateway. After the vault call, the gateway holds `amountToken - c_quote` of `quoteToken`
+(the unspent refund) and `c_mtoken` of `mToken` (the issuance output), plus any pre-existing
+balance `P_quote` of `quoteToken` and `P_mtoken` of `mToken` from before the call.
+`_sweepTokens(msg.sender)` then transfers `amountToken - c_quote + P_quote` of `quoteToken`
+and `c_mtoken + P_mtoken` of `mToken` to the caller. ∎
+
+**Corollary (MID-R015 fixed; unreachable with real Midas).** When the vault consumes the full
+input (`c_quote = amountToken`), the refund component is zero and only `P_quote` is swept.
+When the vault under-pulls (`c_quote < amountToken`), the caller gets back `amountToken -
+c_quote` — exactly the refund that was missing before the fix. Tests `tst_core_midas_015/016/017`
+verify this refund path is now present (GREEN).
+
+**Verification against Midas source** (`DepositVault._depositInstant` line 473-509,
+`RedemptionVault._redeemRequest` line 643-712, `ManageableVault._tokenTransferFromUser` line
+415-429): the real Midas vault always pulls exactly `amountTokenWithoutFee + feeAmount` via
+`safeTransferFrom` with the precisely calculated amount. There is no partial-fill path in the
+current vault logic, so `c_quote = amountToken` always holds under real Midas and the refund
+component is always zero. The sweeping fix is defensive — it protects against future vault
+upgrades that might introduce partial-fill behavior, but it does not fix a reachable bug under
+the current Midas code.
+
+**Corollary (MID-R018/R019 — new finding).** When `P_quote > 0` or `P_mtoken > 0` (from a
+donation, dust, or a prior reverted sub-call), the sweep transfers those pre-existing balances
+to the current caller. The old `balanceAfter - balanceBefore` delta accounting implicitly
+subtracted the pre-existing balance and left it on the gateway; the new whole-balance sweep
+does not. Tests `tst_core_midas_018` (donated quote swept to `depositInstant` caller) and
+`tst_core_midas_019` (donated mToken swept to `redeemInstant` caller) confirm this behavior.
+
+**Claim (no token is lost or created).** The sweep is a `safeTransfer` of the full balance;
+no mint/burn is involved, and the gateway balance of both tokens is zero after a successful
+operation. Token conservation is preserved across the system.
+
+**Proof.** `safeTransfer(to, balance)` moves exactly `balance` from the gateway to `to`. The
+post-state `balanceOf(gateway)` is 0 for both tokens. The caller's incoming flow
+(`safeTransferFrom` pulling `amountToken`) and the vault's flows are independent transfers
+that conserve tokens. Therefore the total supply of both tokens is unchanged by the operation;
+only their distribution changes. ∎
+
+**Tests.** `tst_core_midas_015/016/017` (refund correctness, GREEN),
+`tst_core_midas_018/019` (donation sweep, GREEN), `tst_core_midas_011` (six-decimal round-trip
+on the new code, GREEN).
+
+## 12. Fees do not inflate the phantom (refutes MID-R03)
+
+Source (verified against `RedemptionVault._redeemRequest` line 643-712,
+`RedemptionVault._calcAndValidateRedeem` line 766-801):
+
+```solidity
+// In _calcAndValidateRedeem (line 780-800):
+result.feeAmount = _getFeeAmount(user, tokenOut, amountMTokenIn, isInstant, ...);
+require(amountMTokenIn > result.feeAmount, "RV: amountMTokenIn < fee");
+result.amountMTokenWithoutFee = amountMTokenIn - result.feeAmount;
+
+// In _redeemRequest (line 702-709):
+redeemRequests[requestId] = Request({
+    sender: recipient,
+    tokenOut: tokenOutCopy,
+    status: RequestStatus.Pending,
+    amountMToken: calcResult.amountMTokenWithoutFee,  // NET after fee
+    mTokenRate: mTokenRate,
+    tokenOutRate: tokenOutRate
+});
+```
+
+The Gearbox `MidasRedeemer.pendingTokenOutAmount` reads `request.amountMTokenIn` from
+`redeemRequests(requestId)` (the same struct) and computes
+`amountMToken * mTokenRate_current / tokenOutRate`.
+
+**Claim.** The phantom value is bounded above by the realizable settlement at any non-negative
+mToken rate, regardless of the fee.
+
+**Proof.** Let `a = amountMTokenIn` (gross input), `f = feeAmount`, so
+`amountMTokenWithoutFee = a - f` is what the vault stores in `request.amountMToken`. The
+phantom computes `P(r) = (a - f) * r / s`. The realizable settlement at any approval path with
+rate `r'` is `S(r') = (a - f) * r' / s` (line 508-511, using `request.amountMToken` which is
+the same stored net value). Therefore `P(r) = S(r)` whenever `r = r'` (current-rate approval)
+and `P(r) > S(r')` iff `r > r'` (which is MID-R01, not R03). The fee `f` does not appear in
+any comparison between phantom and settlement — both use the same net `amountMToken`. ∎
+
+**Corollary.** The fee cannot inflate the phantom relative to the realizable settlement. The
+only source of overvaluation is the rate mismatch (MID-R01), not the fee. MID-R03 is refuted.
+
+**Tests.** Verified by inspection of Midas source; the audit harness `AuditMidasRedemptionVault`
+stores `amountMTokenIn` as passed (no fee modeling), and the fuzz tests
+`tst_core_midas_022/023/025` confirm the rate-based math is monotone and bounded.
+
+## Summary of confirmed findings backed by PoC tests
+
+Updated after `7eaa0db` / `dc1d8b5` (the sweeping fix) and after direct verification of the
+Midas vault source at revision `90a5f246`. See `MidasAuditReport.md` for full context.
+
+| Finding | Test | Status |
+| --- | --- | --- |
+| MID-R01 phantom overvalues vs saved settlement rate | `tst_core_midas_001` | Confirmed (verified against `safeBulkApproveRequestAtSavedRate` line 327-341) |
+| MID-R02 cancelled request retains unbacked phantom value | `tst_core_midas_002` | Confirmed (verified: `rejectRequest` line 378-386 locks mToken; no recovery path) |
+| MID-R06 transfer cap not enforced on destination | `tst_core_midas_007` | Confirmed |
+| MID-R09 transfer flag is global, not scoped to liquidated account | `tst_core_midas_010` | Confirmed |
+| MID-R10 `Canceled` (status=2) treated as pending | `tst_core_midas_012` | Confirmed (verified: enum has only Pending/Processed/Canceled; Gearbox checks only status==1) |
+| MID-R15 liquidator sweeps pre-existing residual to next caller | `tst_core_midas_045` | Confirmed |
+| MID-R018 gateway `_sweepTokens` sweeps donated quote to next `depositInstant` caller | `tst_core_midas_018` | Confirmed (NEW, introduced by sweeping fix) |
+| MID-R019 gateway `_sweepTokens` sweeps donated mToken to next `redeemInstant` caller | `tst_core_midas_019` | Confirmed (NEW, introduced by sweeping fix) |
+| ~~MID-R015/016/017~~ residual input stranding | `tst_core_midas_015/016/017` | Unreachable with real Midas (vault always pulls exact amount); defensive sweep fix applied, PoCs GREEN |
+| ~~MID-R03~~ fees inflate phantom | — | Refuted: `request.amountMToken` stores net-after-fee (line 706); phantom uses net amount |
+
+The three `tst_core_midas_015/016/017` tests were RED before the sweeping fix and are now
+GREEN. Direct verification of `ManageableVault._tokenTransferFromUser` (line 415-429) shows
+the real Midas vault always pulls exactly the calculated amount via `safeTransferFrom`, so the
+under-pull scenario they model is not reachable under the current Midas code. The sweeping fix
+is defensive — it protects against future vault upgrades that might introduce partial-fill
+behavior.
+
+The `tst_core_midas_018/019` tests demonstrate a side effect of the same fix: because
+`_sweepTokens` transfers the *entire* gateway balance (not the `balanceAfter - balanceBefore`
+delta used by the old code), any pre-existing balance on the gateway — donations, dust from
+prior operations, or residuals from reverted sub-calls — is swept to the next caller along
+with the legitimate operation output. See `MidasAuditReport.md` section "MID-R018/R019" for
+impact discussion.
+
+MID-R03 was a candidate in the research document ("fees and decimal conversion cannot inflate
+phantom value relative to the net Midas request"). Verification against
+`_redeemRequest` line 702-709 confirms `request.amountMToken = calcResult.amountMTokenWithoutFee`
+(net after fee), and the Gearbox phantom reads `request.amountMTokenIn` (the net value). Fees
+cannot inflate the phantom.
+
+## Proven invariants with passing tests
+
+| Invariant | Proof section | Tests |
+| --- | --- | --- |
+| `_convertToE18` exact for `d <= 18` | 1 | 020, 021 |
+| `_calculateTokenOutAmount` error `< 1` unit | 2 | 023 |
+| Pending amount monotone in mToken rate | 3 | 022 |
+| Zero input -> zero output | 4 | 024 |
+| No overflow for realistic inputs | 5 | 025 |
+| `depositInstantDiff` min-receive bounded by amount | 6 | 026 |
+| `withdraw` transfers exactly `amount` on success | 7 | 030, 037 |
+| `withdraw` reverts atomically on over-withdraw | 7 | 034 |
+| `withdraw` removes only fully-settled redeemers | 7 | 030, 031, 032 |
+| Transfer flag bounded to facade call | 8 | 044 |
+| Collateral forwarding conserves tokens + cleans approvals | 9 | 040, 041, 047 |
+| 6-decimal round-trip preserves funds | 10 | 011, 013 |
+| `_sweepTokens` refunds unspent input (defensive; unreachable with real Midas) | 11 | 015, 016, 017 |
+| `_sweepTokens` sweeps pre-existing balance (R018/R019) | 11 | 018, 019 |
+| `_sweepTokens` conserves tokens (no loss/creation) | 11 | 011, 015-019 |
+| Fees do not inflate phantom (refutes R03) | 12 | source-verified |


### PR DESCRIPTION
## Summary

Standalone Midas audit suite + verified findings report. All Midas-side claims verified against `midas-apps/contracts` at revision `90a5f246` (cloned to `~/Coding/midas`).

## What's new

**33 new audit tests** (all passing on top of `dc1d8b5`) under `contracts/test/audit/midas/`:

| File | Tests | Purpose |
| --- | --- | --- |
| `MidasAuditTestBase.sol` | — | Shared mocks: configurable data feed, issuance/redemption vault, credit manager/facade/access control, AddressProvider |
| `MidasDecimalMath.fuzz.t.sol` | 7 | Fuzz proofs for `_convertToE18` precision, `_calculateTokenOutAmount` monotonicity, overflow, zero-input |
| `MidasFindings.poc.t.sol` | 7 | PoCs for MID-R01, R02, R06, R09, R10, R018, R019 |
| `MidasWithdraw.invariant.t.sol` | 8 | `withdraw`/`withdrawFromRedeemer` accounting: exact transfer, atomic revert, pending-set consistency |
| `MidasLiquidator.unit.t.sol` | 8 | First tests for `MidasLiquidator` (was 0 coverage): collateral forwarding, flag lifecycle, validation reverts |
| `MidasSixDecimalFlow.t.sol` | 2 | End-to-end 6-decimal issuance/redeem/request/withdraw |
| `MidasGatewayResiduals.poc.t.sol` | 3 | Residual-input PoCs — GREEN after sweeping fix (verified unreachable with real Midas) |

**2 reports** under `specs/adapters/midas/`:
- `MidasAuditReport.md` — full audit report with Midas source line references
- `MidasMathematicalProofs.md` — 12 formal proofs

## Verified findings (confirmed against Midas source)

| ID | Severity | Status | Source |
| --- | --- | --- | --- |
| **MID-R01** | high | confirmed | `safeBulkApproveRequestAtSavedRate` (RedemptionVault.sol:327-341) bypasses variation tolerance; phantom uses current rate |
| **MID-R02** | high | confirmed | `rejectRequest` (RedemptionVault.sol:378-386) locks mToken with no recovery path; phantom retains value |
| **MID-R10** | medium | confirmed | `Canceled` (status=2) treated as pending by Gearbox; enum has only Pending/Processed/Canceled (IManageableVault.sol:19-23) |
| **MID-R06** | medium | confirmed | `transferRedeemer` does not check 10-pending cap on destination |
| **MID-R09** | medium | confirmed | `isTransferAllowed` is global, not scoped to liquidated account |
| **MID-R15** | medium | confirmed | Liquidator `_forwardCollateral(true)` sweeps pre-existing residual to next caller |
| **MID-R018/R019** | medium | confirmed (new) | `_sweepTokens` sweeps pre-existing gateway balances to next caller (introduced by `7eaa0db`) |

## Refuted / unreachable

- **~~MID-R03~~** refuted: `request.amountMToken` stores net-after-fee (RedemptionVault.sol:706); phantom uses net amount; fees cannot inflate valuation
- **~~MID-R015/016/017~~** unreachable with real Midas: `_tokenTransferFromUser` (ManageableVault.sol:415-429) always pulls exact amount; sweeping fix in `7eaa0db` is defensive against future partial-fill vault upgrades

## Test results

```
forge test --skip contracts/test/unit/helpers/securitize/SecuritizeNAVFreezeF2.poc.t.sol \
  --match-path "contracts/test/**/midas/**" --summary

Result: 90 passed, 1 failed
```

The 1 failure is an **upstream test-mock regression** (`test_U_MID_G_08`), not an audit-test failure and not a production bug — the upstream `MidasRedemptionVaultMock.redeemRequest` does not pull mToken from the caller while the real Midas vault does, so the new `_sweepMToken()` returns it to the account. The audit harness models the pull correctly.

## Notes

- This PR is audit-only: no production code changes. Findings are documented for the team to triage and decide on fixes.
- `MidasSecurityResearch.md` (pre-existing research base) is not included in this PR — it lives in the main worktree and was the starting point for this verification pass.
- Midas source verification performed against `~/Coding/midas` at revision `90a5f246` (`RedemptionVault.sol`, `DepositVault.sol`, `ManageableVault.sol`, `IManageableVault.sol`).